### PR TITLE
Async yaml reading

### DIFF
--- a/guinget/MainWindow.Designer.vb
+++ b/guinget/MainWindow.Designer.vb
@@ -35,6 +35,13 @@ Partial Class aaformMainWindow
         Me.splitcontainerMainWindow = New System.Windows.Forms.SplitContainer()
         Me.panelPackageListHolder = New System.Windows.Forms.Panel()
         Me.datagridviewPackageList = New System.Windows.Forms.DataGridView()
+        Me.PkgAction = New System.Windows.Forms.DataGridViewComboBoxColumn()
+        Me.PkgStatus = New System.Windows.Forms.DataGridViewTextBoxColumn()
+        Me.PkgName = New System.Windows.Forms.DataGridViewTextBoxColumn()
+        Me.FriendlyName = New System.Windows.Forms.DataGridViewTextBoxColumn()
+        Me.AvailableVersion = New System.Windows.Forms.DataGridViewTextBoxColumn()
+        Me.PkgDescription = New System.Windows.Forms.DataGridViewTextBoxColumn()
+        Me.Manifest = New System.Windows.Forms.DataGridViewTextBoxColumn()
         Me.contextmenustripPackageMenu = New System.Windows.Forms.ContextMenuStrip(Me.components)
         Me.ActionToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
         Me.DoNothingToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
@@ -49,6 +56,8 @@ Partial Class aaformMainWindow
         Me.toolstripbuttonProperties = New System.Windows.Forms.ToolStripButton()
         Me.ToolStripSeparator1 = New System.Windows.Forms.ToolStripSeparator()
         Me.toolstriptextboxSearch = New System.Windows.Forms.ToolStripTextBox()
+        Me.toolstripsplitbuttonSearch = New System.Windows.Forms.ToolStripSplitButton()
+        Me.toolstripmenuitemAdvancedSearch = New System.Windows.Forms.ToolStripMenuItem()
         Me.splitcontainerSidebarAndPkgList = New System.Windows.Forms.SplitContainer()
         Me.panelSidebarHolder = New System.Windows.Forms.Panel()
         Me.tabcontrolSidebar = New System.Windows.Forms.TabControl()
@@ -72,17 +81,8 @@ Partial Class aaformMainWindow
         Me.statusbarMainWindow = New System.Windows.Forms.StatusStrip()
         Me.toolstripstatuslabelPackageCount = New System.Windows.Forms.ToolStripStatusLabel()
         Me.toolstripstatusSplitter = New System.Windows.Forms.ToolStripStatusLabel()
-        Me.toolstripstatuslabelLoadingPackageCount = New System.Windows.Forms.ToolStripStatusLabel()
         Me.toolstripprogressbarLoadingPackages = New System.Windows.Forms.ToolStripProgressBar()
-        Me.toolstripsplitbuttonSearch = New System.Windows.Forms.ToolStripSplitButton()
-        Me.toolstripmenuitemAdvancedSearch = New System.Windows.Forms.ToolStripMenuItem()
-        Me.PkgAction = New System.Windows.Forms.DataGridViewComboBoxColumn()
-        Me.PkgStatus = New System.Windows.Forms.DataGridViewTextBoxColumn()
-        Me.PkgName = New System.Windows.Forms.DataGridViewTextBoxColumn()
-        Me.FriendlyName = New System.Windows.Forms.DataGridViewTextBoxColumn()
-        Me.AvailableVersion = New System.Windows.Forms.DataGridViewTextBoxColumn()
-        Me.PkgDescription = New System.Windows.Forms.DataGridViewTextBoxColumn()
-        Me.Manifest = New System.Windows.Forms.DataGridViewTextBoxColumn()
+        Me.toolstripstatuslabelLoadingPackageCount = New System.Windows.Forms.ToolStripStatusLabel()
         Me.menustripMainWindow.SuspendLayout()
         CType(Me.splitcontainerMainWindow, System.ComponentModel.ISupportInitialize).BeginInit()
         Me.splitcontainerMainWindow.Panel1.SuspendLayout()
@@ -215,6 +215,63 @@ Partial Class aaformMainWindow
         Me.datagridviewPackageList.StandardTab = True
         Me.datagridviewPackageList.TabIndex = 0
         '
+        'PkgAction
+        '
+        Me.PkgAction.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCells
+        Me.PkgAction.HeaderText = "Action"
+        Me.PkgAction.Items.AddRange(New Object() {"Do nothing", "Install"})
+        Me.PkgAction.MinimumWidth = 6
+        Me.PkgAction.Name = "PkgAction"
+        Me.PkgAction.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Automatic
+        Me.PkgAction.Width = 76
+        '
+        'PkgStatus
+        '
+        Me.PkgStatus.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCells
+        Me.PkgStatus.HeaderText = "Status"
+        Me.PkgStatus.MinimumWidth = 6
+        Me.PkgStatus.Name = "PkgStatus"
+        Me.PkgStatus.ReadOnly = True
+        Me.PkgStatus.Width = 77
+        '
+        'PkgName
+        '
+        Me.PkgName.HeaderText = "Package"
+        Me.PkgName.MinimumWidth = 6
+        Me.PkgName.Name = "PkgName"
+        Me.PkgName.ReadOnly = True
+        '
+        'FriendlyName
+        '
+        Me.FriendlyName.HeaderText = "Name"
+        Me.FriendlyName.MinimumWidth = 6
+        Me.FriendlyName.Name = "FriendlyName"
+        Me.FriendlyName.ReadOnly = True
+        '
+        'AvailableVersion
+        '
+        Me.AvailableVersion.HeaderText = "Version"
+        Me.AvailableVersion.MinimumWidth = 6
+        Me.AvailableVersion.Name = "AvailableVersion"
+        Me.AvailableVersion.ReadOnly = True
+        Me.AvailableVersion.ToolTipText = "(will eventually only display latest version and have all older versions in a win" &
+    "dow like Synaptic)"
+        '
+        'PkgDescription
+        '
+        Me.PkgDescription.HeaderText = "Description"
+        Me.PkgDescription.MinimumWidth = 6
+        Me.PkgDescription.Name = "PkgDescription"
+        Me.PkgDescription.ReadOnly = True
+        '
+        'Manifest
+        '
+        Me.Manifest.HeaderText = "Manifest"
+        Me.Manifest.MinimumWidth = 6
+        Me.Manifest.Name = "Manifest"
+        Me.Manifest.ReadOnly = True
+        Me.Manifest.Visible = False
+        '
         'contextmenustripPackageMenu
         '
         Me.contextmenustripPackageMenu.ImageScalingSize = New System.Drawing.Size(20, 20)
@@ -330,6 +387,22 @@ Partial Class aaformMainWindow
         Me.toolstriptextboxSearch.Font = New System.Drawing.Font("Segoe UI", 9.0!)
         Me.toolstriptextboxSearch.Name = "toolstriptextboxSearch"
         Me.toolstriptextboxSearch.Size = New System.Drawing.Size(250, 27)
+        '
+        'toolstripsplitbuttonSearch
+        '
+        Me.toolstripsplitbuttonSearch.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text
+        Me.toolstripsplitbuttonSearch.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.toolstripmenuitemAdvancedSearch})
+        Me.toolstripsplitbuttonSearch.Image = CType(resources.GetObject("toolstripsplitbuttonSearch.Image"), System.Drawing.Image)
+        Me.toolstripsplitbuttonSearch.ImageTransparentColor = System.Drawing.Color.Magenta
+        Me.toolstripsplitbuttonSearch.Name = "toolstripsplitbuttonSearch"
+        Me.toolstripsplitbuttonSearch.Size = New System.Drawing.Size(72, 24)
+        Me.toolstripsplitbuttonSearch.Text = "Search"
+        '
+        'toolstripmenuitemAdvancedSearch
+        '
+        Me.toolstripmenuitemAdvancedSearch.Name = "toolstripmenuitemAdvancedSearch"
+        Me.toolstripmenuitemAdvancedSearch.Size = New System.Drawing.Size(213, 26)
+        Me.toolstripmenuitemAdvancedSearch.Text = "&Advanced search..."
         '
         'splitcontainerSidebarAndPkgList
         '
@@ -563,91 +636,18 @@ Partial Class aaformMainWindow
         Me.toolstripstatusSplitter.Text = "|"
         Me.toolstripstatusSplitter.Visible = False
         '
-        'toolstripstatuslabelLoadingPackageCount
-        '
-        Me.toolstripstatuslabelLoadingPackageCount.Name = "toolstripstatuslabelLoadingPackageCount"
-        Me.toolstripstatuslabelLoadingPackageCount.Size = New System.Drawing.Size(174, 20)
-        Me.toolstripstatuslabelLoadingPackageCount.Text = "Loading package 0 of 0..."
-        Me.toolstripstatuslabelLoadingPackageCount.Visible = False
-        '
         'toolstripprogressbarLoadingPackages
         '
         Me.toolstripprogressbarLoadingPackages.Name = "toolstripprogressbarLoadingPackages"
         Me.toolstripprogressbarLoadingPackages.Size = New System.Drawing.Size(150, 18)
         Me.toolstripprogressbarLoadingPackages.Visible = False
         '
-        'toolstripsplitbuttonSearch
+        'toolstripstatuslabelLoadingPackageCount
         '
-        Me.toolstripsplitbuttonSearch.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text
-        Me.toolstripsplitbuttonSearch.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.toolstripmenuitemAdvancedSearch})
-        Me.toolstripsplitbuttonSearch.Image = CType(resources.GetObject("toolstripsplitbuttonSearch.Image"), System.Drawing.Image)
-        Me.toolstripsplitbuttonSearch.ImageTransparentColor = System.Drawing.Color.Magenta
-        Me.toolstripsplitbuttonSearch.Name = "toolstripsplitbuttonSearch"
-        Me.toolstripsplitbuttonSearch.Size = New System.Drawing.Size(72, 24)
-        Me.toolstripsplitbuttonSearch.Text = "Search"
-        '
-        'toolstripmenuitemAdvancedSearch
-        '
-        Me.toolstripmenuitemAdvancedSearch.Name = "toolstripmenuitemAdvancedSearch"
-        Me.toolstripmenuitemAdvancedSearch.Size = New System.Drawing.Size(224, 26)
-        Me.toolstripmenuitemAdvancedSearch.Text = "&Advanced search..."
-        '
-        'PkgAction
-        '
-        Me.PkgAction.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCells
-        Me.PkgAction.HeaderText = "Action"
-        Me.PkgAction.Items.AddRange(New Object() {"Do nothing", "Install"})
-        Me.PkgAction.MinimumWidth = 6
-        Me.PkgAction.Name = "PkgAction"
-        Me.PkgAction.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Automatic
-        Me.PkgAction.Width = 76
-        '
-        'PkgStatus
-        '
-        Me.PkgStatus.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCells
-        Me.PkgStatus.HeaderText = "Status"
-        Me.PkgStatus.MinimumWidth = 6
-        Me.PkgStatus.Name = "PkgStatus"
-        Me.PkgStatus.ReadOnly = True
-        Me.PkgStatus.Width = 77
-        '
-        'PkgName
-        '
-        Me.PkgName.HeaderText = "Package"
-        Me.PkgName.MinimumWidth = 6
-        Me.PkgName.Name = "PkgName"
-        Me.PkgName.ReadOnly = True
-        '
-        'FriendlyName
-        '
-        Me.FriendlyName.HeaderText = "Name"
-        Me.FriendlyName.MinimumWidth = 6
-        Me.FriendlyName.Name = "FriendlyName"
-        Me.FriendlyName.ReadOnly = True
-        '
-        'AvailableVersion
-        '
-        Me.AvailableVersion.HeaderText = "Version"
-        Me.AvailableVersion.MinimumWidth = 6
-        Me.AvailableVersion.Name = "AvailableVersion"
-        Me.AvailableVersion.ReadOnly = True
-        Me.AvailableVersion.ToolTipText = "(will eventually only display latest version and have all older versions in a win" &
-    "dow like Synaptic)"
-        '
-        'PkgDescription
-        '
-        Me.PkgDescription.HeaderText = "Description"
-        Me.PkgDescription.MinimumWidth = 6
-        Me.PkgDescription.Name = "PkgDescription"
-        Me.PkgDescription.ReadOnly = True
-        '
-        'Manifest
-        '
-        Me.Manifest.HeaderText = "Manifest"
-        Me.Manifest.MinimumWidth = 6
-        Me.Manifest.Name = "Manifest"
-        Me.Manifest.ReadOnly = True
-        Me.Manifest.Visible = False
+        Me.toolstripstatuslabelLoadingPackageCount.Name = "toolstripstatuslabelLoadingPackageCount"
+        Me.toolstripstatuslabelLoadingPackageCount.Size = New System.Drawing.Size(174, 20)
+        Me.toolstripstatuslabelLoadingPackageCount.Text = "Loading package 0 of 0..."
+        Me.toolstripstatuslabelLoadingPackageCount.Visible = False
         '
         'aaformMainWindow
         '

--- a/guinget/MainWindow.Designer.vb
+++ b/guinget/MainWindow.Designer.vb
@@ -543,7 +543,7 @@ Partial Class aaformMainWindow
         'statusbarMainWindow
         '
         Me.statusbarMainWindow.ImageScalingSize = New System.Drawing.Size(20, 20)
-        Me.statusbarMainWindow.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.toolstripstatuslabelPackageCount, Me.toolstripstatusSplitter, Me.toolstripstatuslabelLoadingPackageCount, Me.toolstripprogressbarLoadingPackages})
+        Me.statusbarMainWindow.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.toolstripstatuslabelPackageCount, Me.toolstripstatusSplitter, Me.toolstripprogressbarLoadingPackages, Me.toolstripstatuslabelLoadingPackageCount})
         Me.statusbarMainWindow.Location = New System.Drawing.Point(0, 598)
         Me.statusbarMainWindow.Name = "statusbarMainWindow"
         Me.statusbarMainWindow.Size = New System.Drawing.Size(992, 26)

--- a/guinget/MainWindow.resx
+++ b/guinget/MainWindow.resx
@@ -120,6 +120,11 @@
   <metadata name="menustripMainWindow.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
+  <data name="textboxPackageDetails.Text" xml:space="preserve">
+    <value>No package is selected or the package list hasn't been loaded yet. You can load the package list using the Refresh cache button.
+TODO: Allow the user to have it ask before updating the cache, or always update the cache
+before loading the package list.</value>
+  </data>
   <metadata name="PkgAction.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
@@ -144,11 +149,6 @@
   <metadata name="contextmenustripPackageMenu.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>357, 17</value>
   </metadata>
-  <data name="textboxPackageDetails.Text" xml:space="preserve">
-    <value>No package is selected or the package list hasn't been loaded yet. You can load the package list using the Refresh cache button.
-TODO: Allow the user to have it ask before updating the cache, or always update the cache
-before loading the package list.</value>
-  </data>
   <metadata name="toolstripMainWindow.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>153, 17</value>
   </metadata>
@@ -198,6 +198,12 @@ before loading the package list.</value>
         TgDQASA1MVpwzwAAAABJRU5ErkJggg==
 </value>
   </data>
+  <metadata name="contextmenuSearchTerm.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>629, 17</value>
+  </metadata>
+  <metadata name="statusbarMainWindow.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>855, 17</value>
+  </metadata>
   <data name="toolstripsplitbuttonSearch.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
@@ -213,10 +219,4 @@ before loading the package list.</value>
         TgDQASA1MVpwzwAAAABJRU5ErkJggg==
 </value>
   </data>
-  <metadata name="contextmenuSearchTerm.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>629, 17</value>
-  </metadata>
-  <metadata name="statusbarMainWindow.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>855, 17</value>
-  </metadata>
 </root>

--- a/guinget/MainWindow.resx
+++ b/guinget/MainWindow.resx
@@ -120,11 +120,6 @@
   <metadata name="menustripMainWindow.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
-  <data name="textboxPackageDetails.Text" xml:space="preserve">
-    <value>No package is selected or the package list hasn't been loaded yet. You can load the package list using the Refresh cache button.
-TODO: Allow the user to have it ask before updating the cache, or always update the cache
-before loading the package list.</value>
-  </data>
   <metadata name="PkgAction.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
@@ -149,6 +144,11 @@ before loading the package list.</value>
   <metadata name="contextmenustripPackageMenu.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>357, 17</value>
   </metadata>
+  <data name="textboxPackageDetails.Text" xml:space="preserve">
+    <value>No package is selected or the package list hasn't been loaded yet. You can load the package list using the Refresh cache button.
+TODO: Allow the user to have it ask before updating the cache, or always update the cache
+before loading the package list.</value>
+  </data>
   <metadata name="toolstripMainWindow.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>153, 17</value>
   </metadata>
@@ -198,12 +198,6 @@ before loading the package list.</value>
         TgDQASA1MVpwzwAAAABJRU5ErkJggg==
 </value>
   </data>
-  <metadata name="contextmenuSearchTerm.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>629, 17</value>
-  </metadata>
-  <metadata name="statusbarMainWindow.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>855, 17</value>
-  </metadata>
   <data name="toolstripsplitbuttonSearch.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
@@ -219,4 +213,10 @@ before loading the package list.</value>
         TgDQASA1MVpwzwAAAABJRU5ErkJggg==
 </value>
   </data>
+  <metadata name="contextmenuSearchTerm.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>629, 17</value>
+  </metadata>
+  <metadata name="statusbarMainWindow.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>855, 17</value>
+  </metadata>
 </root>

--- a/guinget/MainWindow.vb
+++ b/guinget/MainWindow.vb
@@ -101,9 +101,9 @@ Public Class aaformMainWindow
             Row.Cells.Item(5).Value = Await PackageListTools.GetPackageInfoFromYaml(Row.Cells.Item(6).Value.ToString, "Description")
 
             ' Update loading statusbar label and progressbar.
-            aaformMainWindow.toolstripstatuslabelLoadingPackageCount.Text = "Loading details for package " & Row.Index.ToString & " of " & (aaformMainWindow.datagridviewPackageList.Rows.Count - 1).ToString & "..."
+            'aaformMainWindow.toolstripstatuslabelLoadingPackageCount.Text = "Loading details for package " & Row.Index.ToString & " of " & (aaformMainWindow.datagridviewPackageList.Rows.Count - 1).ToString & "..."
             ' Make the progress bar progress.
-            aaformMainWindow.toolstripprogressbarLoadingPackages.PerformStep()
+            'aaformMainWindow.toolstripprogressbarLoadingPackages.PerformStep()
             ' Update the main form to show the current info.
             aaformMainWindow.Update()
         Next

--- a/guinget/MainWindow.vb
+++ b/guinget/MainWindow.vb
@@ -50,12 +50,12 @@ Public Class aaformMainWindow
         ' Change mouse cursor to the "working" one.
         aaformMainWindow.Cursor = Cursors.WaitCursor
 
-        ' Clear the rows.
-        aaformMainWindow.datagridviewPackageList.Rows.Clear()
-
         ' Hide the datagridview while we're updating to make
         ' this slightly faster.
         aaformMainWindow.datagridviewPackageList.Visible = False
+
+        ' Clear the rows.
+        aaformMainWindow.datagridviewPackageList.Rows.Clear()
 
         ' Display loading progress bar and stuff.
         aaformMainWindow.toolstripstatusSplitter.Visible = True

--- a/guinget/MainWindow.vb
+++ b/guinget/MainWindow.vb
@@ -92,6 +92,9 @@ Public Class aaformMainWindow
         ' a result of not clearing the rows before filling them.
         aaformMainWindow.toolstripprogressbarLoadingPackages.Maximum = aaformMainWindow.datagridviewPackageList.Rows.Count
 
+        ' Update loading label.
+        aaformMainWindow.toolstripstatuslabelLoadingPackageCount.Text = "Loading package details..."
+
         ' Now we load the details for each row.
         For Each Row As DataGridViewRow In aaformMainWindow.datagridviewPackageList.Rows
             ' Load package ID column.
@@ -104,7 +107,6 @@ Public Class aaformMainWindow
             Row.Cells.Item(5).Value = Await PackageListTools.GetPackageInfoFromYaml(Row.Cells.Item(6).Value.ToString, "Description")
 
             ' Update loading statusbar label and progressbar.
-            'aaformMainWindow.toolstripstatuslabelLoadingPackageCount.Text = "Loading details for package " & Row.Index.ToString & " of " & (aaformMainWindow.datagridviewPackageList.Rows.Count - 1).ToString & "..."
             ' Make the progress bar progress.
             'aaformMainWindow.toolstripprogressbarLoadingPackages.PerformStep()
             ' Update the main form to show the current info.

--- a/guinget/MainWindow.vb
+++ b/guinget/MainWindow.vb
@@ -114,13 +114,13 @@ Public Class aaformMainWindow
         ' Now we load the details for each row.
         For Each Row As DataGridViewRow In aaformMainWindow.datagridviewPackageList.Rows
             ' Load package ID column.
-            Row.Cells.Item(2).Value = Await PackageListTools.GetPackageInfoFromYaml(Row.Cells.Item(6).Value.ToString, "Id")
+            Row.Cells.Item(2).Value = Await PackageListTools.GetPackageInfoFromYamlAsync(Row.Cells.Item(6).Value.ToString, "Id")
             ' Load package name column.
-            Row.Cells.Item(3).Value = Await PackageListTools.GetPackageInfoFromYaml(Row.Cells.Item(6).Value.ToString, "Name")
+            Row.Cells.Item(3).Value = Await PackageListTools.GetPackageInfoFromYamlAsync(Row.Cells.Item(6).Value.ToString, "Name")
             ' Load package version column.
-            Row.Cells.Item(4).Value = Await PackageListTools.GetPackageInfoFromYaml(Row.Cells.Item(6).Value.ToString, "Version")
+            Row.Cells.Item(4).Value = Await PackageListTools.GetPackageInfoFromYamlAsync(Row.Cells.Item(6).Value.ToString, "Version")
             ' Load package description column.
-            Row.Cells.Item(5).Value = Await PackageListTools.GetPackageInfoFromYaml(Row.Cells.Item(6).Value.ToString, "Description")
+            Row.Cells.Item(5).Value = Await PackageListTools.GetPackageInfoFromYamlAsync(Row.Cells.Item(6).Value.ToString, "Description")
             ' Update the package list so it doesn't show loading for everything until it's done.
             aaformMainWindow.datagridviewPackageList.Update()
         Next

--- a/guinget/MainWindow.vb
+++ b/guinget/MainWindow.vb
@@ -62,6 +62,11 @@ Public Class aaformMainWindow
         aaformMainWindow.toolstripprogressbarLoadingPackages.Visible = True
         aaformMainWindow.toolstripstatuslabelLoadingPackageCount.Visible = True
 
+        ' Update main window so the "loading package list, please wait..." label
+        ' looks ok when the package list is hidden, along with anything else
+        ' that needs to be refreshed, like the details textbox.
+        aaformMainWindow.Update()
+
         ' Now we populate the Manifest column with each manifest.
         Dim ManifestPaths() As String = PackageListTools.GetManifests.TrimEnd.Split(CType("?", Char()))
 
@@ -79,8 +84,8 @@ Public Class aaformMainWindow
             aaformMainWindow.toolstripstatuslabelLoadingPackageCount.Text = "Loading package " & i.ToString & " of " & (ManifestPaths.Count - 2).ToString & "..."
             ' Make the progress bar progress.
             aaformMainWindow.toolstripprogressbarLoadingPackages.PerformStep()
-            ' Update the main form to show the current info.
-            aaformMainWindow.Update()
+            ' Update the statusbar to show the current info.
+            aaformMainWindow.statusbarMainWindow.Update()
         Next
 
         ' Update the main window now that the list is loaded.
@@ -109,6 +114,8 @@ Public Class aaformMainWindow
             Row.Cells.Item(4).Value = Await PackageListTools.GetPackageInfoFromYaml(Row.Cells.Item(6).Value.ToString, "Version")
             ' Load package description column.
             Row.Cells.Item(5).Value = Await PackageListTools.GetPackageInfoFromYaml(Row.Cells.Item(6).Value.ToString, "Description")
+            ' Update the package list so it doesn't show loading for everything until it's done.
+            aaformMainWindow.datagridviewPackageList.Update()
         Next
 
         ' Update the main window again.

--- a/guinget/MainWindow.vb
+++ b/guinget/MainWindow.vb
@@ -85,8 +85,8 @@ Public Class aaformMainWindow
             ' I timed this, and it took only 0.1 seconds or so
             ' without updating the status text, as opposed to
             ' over a second when displaying progress.
-            ' Maybe give the user a way to turn off the progress status
-            ' if they want it to go as fast as possible.
+            ' Maybe give the user a way to turn off the progress
+            ' status if they want it to go as fast as possible.
             ' Could be "ShowProgressWhileLoadingManifests".
             aaformMainWindow.toolstripstatuslabelLoadingPackageCount.Text = "Loading package " & i.ToString & " of " & (ManifestPaths.Count - 2).ToString & "..."
             ' Make the progress bar progress.

--- a/guinget/MainWindow.vb
+++ b/guinget/MainWindow.vb
@@ -84,6 +84,8 @@ Public Class aaformMainWindow
             aaformMainWindow.Update()
         Next
 
+        aaformMainWindow.Update()
+
         ' Reset progress bar to 0.
         aaformMainWindow.toolstripprogressbarLoadingPackages.Value = 0
 
@@ -98,6 +100,9 @@ Public Class aaformMainWindow
         ' Show datagridview again.
         aaformMainWindow.datagridviewPackageList.Visible = True
 
+        aaformMainWindow.Update()
+
+
         ' Now we load the details for each row.
         For Each Row As DataGridViewRow In aaformMainWindow.datagridviewPackageList.Rows
             ' Load package ID column.
@@ -111,7 +116,7 @@ Public Class aaformMainWindow
         Next
 
         ' Set the progressbar to the maximum to make it look finished.
-        aaformMainWindow.toolstripprogressbarLoadingPackages.Value = aaformMainWindow.toolstripprogressbarLoadingPackages.Maximum
+        'aaformMainWindow.toolstripprogressbarLoadingPackages.Value = aaformMainWindow.toolstripprogressbarLoadingPackages.Maximum
 
         ' Hide the loading label and progress bar as well as the
         ' fake splitter label.

--- a/guinget/MainWindow.vb
+++ b/guinget/MainWindow.vb
@@ -108,12 +108,6 @@ Public Class aaformMainWindow
             Row.Cells.Item(4).Value = Await PackageListTools.GetPackageInfoFromYaml(Row.Cells.Item(6).Value.ToString, "Version")
             ' Load package description column.
             Row.Cells.Item(5).Value = Await PackageListTools.GetPackageInfoFromYaml(Row.Cells.Item(6).Value.ToString, "Description")
-
-            ' Update loading statusbar label and progressbar.
-            ' Make the progress bar progress.
-            'aaformMainWindow.toolstripprogressbarLoadingPackages.PerformStep()
-            ' Update the main form to show the current info.
-            aaformMainWindow.Update()
         Next
 
         ' Set the progressbar to the maximum to make it look finished.
@@ -132,6 +126,8 @@ Public Class aaformMainWindow
 
         ' Change mouse cursor to the default one.
         aaformMainWindow.Cursor = Cursors.Default
+
+
 
         ' Display number of packages loaded. This really should be
         ' changed to calculate the number of currently-visible rows

--- a/guinget/MainWindow.vb
+++ b/guinget/MainWindow.vb
@@ -95,6 +95,9 @@ Public Class aaformMainWindow
         ' Update loading label.
         aaformMainWindow.toolstripstatuslabelLoadingPackageCount.Text = "Loading package details..."
 
+        ' Show datagridview again.
+        aaformMainWindow.datagridviewPackageList.Visible = True
+
         ' Now we load the details for each row.
         For Each Row As DataGridViewRow In aaformMainWindow.datagridviewPackageList.Rows
             ' Load package ID column.
@@ -125,8 +128,7 @@ Public Class aaformMainWindow
         ' Reset progress bar to 0.
         aaformMainWindow.toolstripprogressbarLoadingPackages.Value = 0
 
-        ' Show datagridview again.
-        aaformMainWindow.datagridviewPackageList.Visible = True
+
 
         ' Change mouse cursor to the default one.
         aaformMainWindow.Cursor = Cursors.Default

--- a/guinget/MainWindow.vb
+++ b/guinget/MainWindow.vb
@@ -34,7 +34,7 @@ Public Class aaformMainWindow
         AddPackageEntryToList()
     End Sub
 
-    Private Shared Sub AddPackageEntryToList()
+    Private Shared Async Sub AddPackageEntryToList()
 
         ' Adds a package to the package list based on what's in the manifests folder.
         ' TODO: Make sure the package's status is properly set. For now, it'll
@@ -92,13 +92,13 @@ Public Class aaformMainWindow
         ' Now we load the details for each row.
         For Each Row As DataGridViewRow In aaformMainWindow.datagridviewPackageList.Rows
             ' Load package ID column.
-            Row.Cells.Item(2).Value = PackageListTools.GetPackageInfoFromYaml(Row.Cells.Item(6).Value.ToString, "Id")
+            Row.Cells.Item(2).Value = Await PackageListTools.GetPackageInfoFromYaml(Row.Cells.Item(6).Value.ToString, "Id")
             ' Load package name column.
-            Row.Cells.Item(3).Value = PackageListTools.GetPackageInfoFromYaml(Row.Cells.Item(6).Value.ToString, "Name")
+            Row.Cells.Item(3).Value = Await PackageListTools.GetPackageInfoFromYaml(Row.Cells.Item(6).Value.ToString, "Name")
             ' Load package version column.
-            Row.Cells.Item(4).Value = PackageListTools.GetPackageInfoFromYaml(Row.Cells.Item(6).Value.ToString, "Version")
+            Row.Cells.Item(4).Value = Await PackageListTools.GetPackageInfoFromYaml(Row.Cells.Item(6).Value.ToString, "Version")
             ' Load package description column.
-            Row.Cells.Item(5).Value = PackageListTools.GetPackageInfoFromYaml(Row.Cells.Item(6).Value.ToString, "Description")
+            Row.Cells.Item(5).Value = Await PackageListTools.GetPackageInfoFromYaml(Row.Cells.Item(6).Value.ToString, "Description")
 
             ' Update loading statusbar label and progressbar.
             aaformMainWindow.toolstripstatuslabelLoadingPackageCount.Text = "Loading details for package " & Row.Index.ToString & " of " & (aaformMainWindow.datagridviewPackageList.Rows.Count - 1).ToString & "..."

--- a/guinget/MainWindow.vb
+++ b/guinget/MainWindow.vb
@@ -59,9 +59,8 @@ Public Class aaformMainWindow
 
         ' Display loading progress bar and stuff.
         aaformMainWindow.toolstripstatusSplitter.Visible = True
-        aaformMainWindow.toolstripstatuslabelLoadingPackageCount.Visible = True
         aaformMainWindow.toolstripprogressbarLoadingPackages.Visible = True
-
+        aaformMainWindow.toolstripstatuslabelLoadingPackageCount.Visible = True
 
         ' Now we populate the Manifest column with each manifest.
         Dim ManifestPaths() As String = PackageListTools.GetManifests.TrimEnd.Split(CType("?", Char()))
@@ -87,13 +86,9 @@ Public Class aaformMainWindow
         ' Update the main window now that the list is loaded.
         aaformMainWindow.Update()
 
-        ' Reset progress bar to 0.
-        aaformMainWindow.toolstripprogressbarLoadingPackages.Value = 0
-
-        ' Set progress bar maximum to number of rows, in case there are new
-        ' rows. There shouldn't be any new rows though, as that would be
-        ' a result of not clearing the rows before filling them.
-        aaformMainWindow.toolstripprogressbarLoadingPackages.Maximum = aaformMainWindow.datagridviewPackageList.Rows.Count
+        ' Set the progressbar to the maximum to make it look finished.
+        aaformMainWindow.toolstripprogressbarLoadingPackages.Maximum = 100
+        aaformMainWindow.toolstripprogressbarLoadingPackages.Value = 100
 
         ' Update loading label.
         aaformMainWindow.toolstripstatuslabelLoadingPackageCount.Text = "Loading package details..."
@@ -103,7 +98,6 @@ Public Class aaformMainWindow
 
         ' Update the main window again after making the list visible and changing the loading label.
         aaformMainWindow.Update()
-
 
         ' Now we load the details for each row.
         For Each Row As DataGridViewRow In aaformMainWindow.datagridviewPackageList.Rows
@@ -117,24 +111,20 @@ Public Class aaformMainWindow
             Row.Cells.Item(5).Value = Await PackageListTools.GetPackageInfoFromYaml(Row.Cells.Item(6).Value.ToString, "Description")
         Next
 
-        ' Set the progressbar to the maximum to make it look finished.
-        'aaformMainWindow.toolstripprogressbarLoadingPackages.Value = aaformMainWindow.toolstripprogressbarLoadingPackages.Maximum
+        ' Update the main window again.
+        aaformMainWindow.Update()
 
         ' Hide the loading label and progress bar as well as the
         ' fake splitter label.
         aaformMainWindow.toolstripstatusSplitter.Visible = False
-        aaformMainWindow.toolstripstatuslabelLoadingPackageCount.Visible = False
         aaformMainWindow.toolstripprogressbarLoadingPackages.Visible = False
+        aaformMainWindow.toolstripstatuslabelLoadingPackageCount.Visible = False
 
         ' Reset progress bar to 0.
         aaformMainWindow.toolstripprogressbarLoadingPackages.Value = 0
 
-
-
         ' Change mouse cursor to the default one.
         aaformMainWindow.Cursor = Cursors.Default
-
-
 
         ' Display number of packages loaded. This really should be
         ' changed to calculate the number of currently-visible rows

--- a/guinget/MainWindow.vb
+++ b/guinget/MainWindow.vb
@@ -81,6 +81,13 @@ Public Class aaformMainWindow
             aaformMainWindow.datagridviewPackageList.Rows.Add("Do nothing", "Unknown", "Loading...", "Loading...", "Loading...", "Loading...", ManifestPaths(i))
 
             ' Update loading statusbar label and progressbar.
+
+            ' I timed this, and it took only 0.1 seconds or so
+            ' without updating the status text, as opposed to
+            ' over a second when displaying progress.
+            ' Maybe give the user a way to turn off the progress status
+            ' if they want it to go as fast as possible.
+            ' Could be "ShowProgressWhileLoadingManifests".
             aaformMainWindow.toolstripstatuslabelLoadingPackageCount.Text = "Loading package " & i.ToString & " of " & (ManifestPaths.Count - 2).ToString & "..."
             ' Make the progress bar progress.
             aaformMainWindow.toolstripprogressbarLoadingPackages.PerformStep()

--- a/guinget/MainWindow.vb
+++ b/guinget/MainWindow.vb
@@ -34,7 +34,7 @@ Public Class aaformMainWindow
         AddPackageEntryToListAsync()
     End Sub
 
-    Private Shared Async Sub AddPackageEntryToListAsync()
+    Private Shared Async Function AddPackageEntryToListAsync() As Task
 
         ' Adds a package to the package list based on what's in the manifests folder.
         ' TODO: Make sure the package's status is properly set. For now, it'll
@@ -148,7 +148,7 @@ Public Class aaformMainWindow
         ' https://stackoverflow.com/a/44661255
         aaformMainWindow.toolstripstatuslabelPackageCount.Text = (aaformMainWindow.datagridviewPackageList.RowCount - 1).ToString &
             " packages listed."
-    End Sub
+    End Function
 
     Private Sub datagridviewPackageList_CellMouseDown(sender As Object, e As DataGridViewCellMouseEventArgs) Handles datagridviewPackageList.CellMouseDown
         ' Code based on this SO answer:
@@ -267,6 +267,14 @@ Public Class aaformMainWindow
         ' Reload the package list with the new manifests.
         AddPackageEntryToListAsync()
     End Sub
+
+    ' If we wanted to, we could allow the package list to be loaded on application
+    ' startup, but since loading the files list isn't async yet, it takes a bit
+    ' longer than not loading the files list on startup and requiring a click
+    ' on the "Refresh cache" button.
+    'Private Async Sub aaformMainWindow_Load(sender As Object, e As EventArgs) Handles MyBase.Load
+    '    Await AddPackageEntryToListAsync()
+    'End Sub
 
 
 

--- a/guinget/MainWindow.vb
+++ b/guinget/MainWindow.vb
@@ -84,6 +84,7 @@ Public Class aaformMainWindow
             aaformMainWindow.Update()
         Next
 
+        ' Update the main window now that the list is loaded.
         aaformMainWindow.Update()
 
         ' Reset progress bar to 0.
@@ -100,6 +101,7 @@ Public Class aaformMainWindow
         ' Show datagridview again.
         aaformMainWindow.datagridviewPackageList.Visible = True
 
+        ' Update the main window again after making the list visible and changing the loading label.
         aaformMainWindow.Update()
 
 

--- a/guinget/MainWindow.vb
+++ b/guinget/MainWindow.vb
@@ -31,10 +31,10 @@ Public Class aaformMainWindow
 
         ' Add packages to the list using what's stored in
         ' %AppData%\winget-frontends\pkglist\manifests.
-        AddPackageEntryToList()
+        AddPackageEntryToListAsync()
     End Sub
 
-    Private Shared Async Sub AddPackageEntryToList()
+    Private Shared Async Sub AddPackageEntryToListAsync()
 
         ' Adds a package to the package list based on what's in the manifests folder.
         ' TODO: Make sure the package's status is properly set. For now, it'll
@@ -43,6 +43,9 @@ Public Class aaformMainWindow
 
         ' TODO: If I can figure out a way to make this async, I will,
         ' but for now non-async is better than nothing.
+        ' Update 5/27/2020: This sub is now async for getting
+        ' package details, but not async for getting the package
+        ' list yet.
 
         ' Change mouse cursor to the "working" one.
         aaformMainWindow.Cursor = Cursors.WaitCursor
@@ -251,7 +254,7 @@ Public Class aaformMainWindow
         MessageBox.Show("Please run update-manifests.bat located in guinget's EXE directory (may also be in the" &
                         " repository's root folder), then click OK when it's finished.", "Refresh cache")
         ' Reload the package list with the new manifests.
-        AddPackageEntryToList()
+        AddPackageEntryToListAsync()
     End Sub
 
 

--- a/guinget/MainWindow.vb
+++ b/guinget/MainWindow.vb
@@ -272,6 +272,7 @@ Public Class aaformMainWindow
     ' startup, but since loading the files list isn't async yet, it takes a bit
     ' longer than not loading the files list on startup and requiring a click
     ' on the "Refresh cache" button.
+    ' Not sure if this is faster or slower with Await.
     'Private Async Sub aaformMainWindow_Load(sender As Object, e As EventArgs) Handles MyBase.Load
     '    Await AddPackageEntryToListAsync()
     'End Sub

--- a/guinget/guinget.vbproj
+++ b/guinget/guinget.vbproj
@@ -98,6 +98,7 @@
     <Compile Include="My Project\Application.Designer.vb">
       <AutoGen>True</AutoGen>
       <DependentUpon>Application.myapp</DependentUpon>
+      <DesignTime>True</DesignTime>
     </Compile>
     <Compile Include="My Project\Resources.Designer.vb">
       <AutoGen>True</AutoGen>

--- a/libguinget/PackageListTools.vb
+++ b/libguinget/PackageListTools.vb
@@ -74,13 +74,15 @@ Public Class PackageListTools
 
     End Function
 
-    Async Function GetManifestInfoAsync(YamlInput As StreamReader, RequestedKey As String) As Task
+    Async Function GetManifestInfoAsync(YamlInput As StreamReader, RequestedKey As String) As Task(Of String)
         ' Load the stream in.
         Dim YamlStream As New YamlStream
         YamlStream.Load(YamlInput)
 
         ' Create variable for root node.
         Dim YamlRoot = CType(YamlStream.Documents(0).RootNode, YamlMappingNode)
+
+        Dim FinalList As String = String.Empty
 
         For Each Entry In YamlRoot.Children
 
@@ -92,7 +94,7 @@ Public Class PackageListTools
             If CType(Entry.Key, YamlScalarNode).Value = RequestedKey Then
                 ' If we're looking at an ID, add it to the package list array.
 
-                Return Entry.Value.ToString
+                FinalList = FinalList & Await Entry.Value.ToString
                 'MessageBox.Show(Entry.Value.ToString)
 
             End If

--- a/libguinget/PackageListTools.vb
+++ b/libguinget/PackageListTools.vb
@@ -29,7 +29,7 @@ Imports YamlDotNet.RepresentationModel
 
 Public Class PackageListTools
 
-    Public Shared Async Function GetPackageInfoFromYaml(ManifestPath As String, RequestedKey As String) As Task(Of String)
+    Public Shared Async Function GetPackageInfoFromYamlAsync(ManifestPath As String, RequestedKey As String) As Task(Of String)
 
         ' Load in the file and get whatever was requested of it.
 

--- a/libguinget/PackageListTools.vb
+++ b/libguinget/PackageListTools.vb
@@ -50,34 +50,11 @@ Public Class PackageListTools
         Dim PackageInfo As String = String.Empty
         Using Input As StreamReader = File.OpenText(ManifestPath)
 
+            ' Getting package info using async.
             PackageInfo = Await GetManifestInfoAsync(Input, RequestedKey)
         End Using
 
         Return PackageInfo
-
-        ' Load the stream in.
-        'Dim YamlStream As New YamlStream
-        'YamlStream.Load(Input)
-
-        '' Create variable for root node.
-        'Dim YamlRoot = CType(YamlStream.Documents(0).RootNode, YamlMappingNode)
-
-        'For Each Entry In YamlRoot.Children
-
-        '    ' If the requested key exists, then use it.
-        '    ' This check doesn't work; maybe something
-        '    ' like an ordered list would be better:
-        '    ' https://stackoverflow.com/a/30097560
-        '    ' Check each entry in the YAML root node.
-        '    If CType(Entry.Key, YamlScalarNode).Value = RequestedKey Then
-        '        ' If we're looking at an ID, add it to the package list array.
-
-        '        Return Entry.Value.ToString
-        '        'MessageBox.Show(Entry.Value.ToString)
-
-        '    End If
-
-        'Next
 
     End Function
 
@@ -86,25 +63,25 @@ Public Class PackageListTools
         Dim YamlStream As New YamlStream
         YamlStream.Load(YamlInput)
 
-            ' Create variable for root node.
-            Dim YamlRoot = CType(YamlStream.Documents(0).RootNode, YamlMappingNode)
+        ' Create variable for root node.
+        Dim YamlRoot = CType(YamlStream.Documents(0).RootNode, YamlMappingNode)
 
-            Dim FinalInfo As String = String.Empty
+        Dim EntryValue As String = String.Empty
 
         For Each Entry In YamlRoot.Children
 
-            ' If the requested key exists, then use it.
+            ' If the requested key exists, then return it.
             ' This check doesn't work; maybe something
             ' like an ordered list would be better:
             ' https://stackoverflow.com/a/30097560
             ' Check each entry in the YAML root node.
             If CType(Entry.Key, YamlScalarNode).Value = RequestedKey Then
-                ' If we're looking at an ID, add it to the package list array.
-
-                Return Entry.Value.ToString
-                'MessageBox.Show(Entry.Value.ToString)
+                ' If we're looking at what's requested, return it.
+                EntryValue = Entry.Value.ToString
             End If
         Next
+
+        Return EntryValue
 
     End Function
 

--- a/libguinget/PackageListTools.vb
+++ b/libguinget/PackageListTools.vb
@@ -89,7 +89,7 @@ Public Class PackageListTools
         ' Create variable for root node.
         Dim YamlRoot = CType(YamlStream.Documents(0).RootNode, YamlMappingNode)
 
-        Dim FinalList As String = String.Empty
+        Dim FinalInfo As String = String.Empty
 
         For Each Entry In YamlRoot.Children
 
@@ -101,12 +101,12 @@ Public Class PackageListTools
             If CType(Entry.Key, YamlScalarNode).Value = RequestedKey Then
                 ' If we're looking at an ID, add it to the package list array.
 
-                Return Entry.Value.ToString
+                FinalInfo = Entry.Value.ToString
                 'MessageBox.Show(Entry.Value.ToString)
-
             End If
-
         Next
+
+        Return FinalInfo
     End Function
 
     Public Shared Function GetManifests() As String

--- a/libguinget/PackageListTools.vb
+++ b/libguinget/PackageListTools.vb
@@ -29,7 +29,7 @@ Imports YamlDotNet.RepresentationModel
 
 Public Class PackageListTools
 
-    Public Shared Function GetPackageInfoFromYaml(ManifestPath As String, RequestedKey As String) As String
+    Public Shared Async Function GetPackageInfoFromYaml(ManifestPath As String, RequestedKey As String) As Task(Of String)
 
         ' Load in the file and get whatever was requested of it.
 
@@ -46,35 +46,42 @@ Public Class PackageListTools
         ' This working example is described in the following
         ' StackOverflow answer:
         ' https://stackoverflow.com/a/46897520
+
+        Dim PackageInfo As String = String.Empty
         Using Input As StreamReader = File.OpenText(ManifestPath)
 
-            ' Load the stream in.
-            Dim YamlStream As New YamlStream
-            YamlStream.Load(Input)
+            PackageInfo = Await GetManifestInfoAsync(Input, RequestedKey)
+        End Using
 
-            ' Create variable for root node.
-            Dim YamlRoot = CType(YamlStream.Documents(0).RootNode, YamlMappingNode)
+        Return PackageInfo
 
-            For Each Entry In YamlRoot.Children
+        ' Load the stream in.
+        'Dim YamlStream As New YamlStream
+        'YamlStream.Load(Input)
 
-                ' If the requested key exists, then use it.
-                ' This check doesn't work; maybe something
-                ' like an ordered list would be better:
-                ' https://stackoverflow.com/a/30097560
-                ' Check each entry in the YAML root node.
-                If CType(Entry.Key, YamlScalarNode).Value = RequestedKey Then
-                    ' If we're looking at an ID, add it to the package list array.
+        '' Create variable for root node.
+        'Dim YamlRoot = CType(YamlStream.Documents(0).RootNode, YamlMappingNode)
 
-                    Return Entry.Value.ToString
-                    'MessageBox.Show(Entry.Value.ToString)
+        'For Each Entry In YamlRoot.Children
 
-                End If
+        '    ' If the requested key exists, then use it.
+        '    ' This check doesn't work; maybe something
+        '    ' like an ordered list would be better:
+        '    ' https://stackoverflow.com/a/30097560
+        '    ' Check each entry in the YAML root node.
+        '    If CType(Entry.Key, YamlScalarNode).Value = RequestedKey Then
+        '        ' If we're looking at an ID, add it to the package list array.
 
-            Next
+        '        Return Entry.Value.ToString
+        '        'MessageBox.Show(Entry.Value.ToString)
+
+        '    End If
+
+        'Next
 
     End Function
 
-    Async Function GetManifestInfoAsync(YamlInput As StreamReader, RequestedKey As String) As Task(Of String)
+    Friend Shared Async Function GetManifestInfoAsync(YamlInput As StreamReader, RequestedKey As String) As Task(Of String)
         ' Load the stream in.
         Dim YamlStream As New YamlStream
         YamlStream.Load(YamlInput)
@@ -94,7 +101,7 @@ Public Class PackageListTools
             If CType(Entry.Key, YamlScalarNode).Value = RequestedKey Then
                 ' If we're looking at an ID, add it to the package list array.
 
-                FinalList = FinalList & Await Entry.Value.ToString
+                Return Entry.Value.ToString
                 'MessageBox.Show(Entry.Value.ToString)
 
             End If

--- a/libguinget/PackageListTools.vb
+++ b/libguinget/PackageListTools.vb
@@ -74,7 +74,7 @@ Public Class PackageListTools
 
     End Function
 
-    Async Function GetManifestInfo(YamlInput As StreamReader, RequestedKey As String) As Task
+    Async Function GetManifestInfoAsync(YamlInput As StreamReader, RequestedKey As String) As Task
 
     End Function
 

--- a/libguinget/PackageListTools.vb
+++ b/libguinget/PackageListTools.vb
@@ -86,10 +86,10 @@ Public Class PackageListTools
         Dim YamlStream As New YamlStream
         YamlStream.Load(YamlInput)
 
-        ' Create variable for root node.
-        Dim YamlRoot = CType(YamlStream.Documents(0).RootNode, YamlMappingNode)
+            ' Create variable for root node.
+            Dim YamlRoot = CType(YamlStream.Documents(0).RootNode, YamlMappingNode)
 
-        Dim FinalInfo As String = String.Empty
+            Dim FinalInfo As String = String.Empty
 
         For Each Entry In YamlRoot.Children
 
@@ -101,12 +101,11 @@ Public Class PackageListTools
             If CType(Entry.Key, YamlScalarNode).Value = RequestedKey Then
                 ' If we're looking at an ID, add it to the package list array.
 
-                FinalInfo = Entry.Value.ToString
+                Return Entry.Value.ToString
                 'MessageBox.Show(Entry.Value.ToString)
             End If
         Next
 
-        Return FinalInfo
     End Function
 
     Public Shared Function GetManifests() As String

--- a/libguinget/PackageListTools.vb
+++ b/libguinget/PackageListTools.vb
@@ -75,7 +75,29 @@ Public Class PackageListTools
     End Function
 
     Async Function GetManifestInfoAsync(YamlInput As StreamReader, RequestedKey As String) As Task
+        ' Load the stream in.
+        Dim YamlStream As New YamlStream
+        YamlStream.Load(YamlInput)
 
+        ' Create variable for root node.
+        Dim YamlRoot = CType(YamlStream.Documents(0).RootNode, YamlMappingNode)
+
+        For Each Entry In YamlRoot.Children
+
+            ' If the requested key exists, then use it.
+            ' This check doesn't work; maybe something
+            ' like an ordered list would be better:
+            ' https://stackoverflow.com/a/30097560
+            ' Check each entry in the YAML root node.
+            If CType(Entry.Key, YamlScalarNode).Value = RequestedKey Then
+                ' If we're looking at an ID, add it to the package list array.
+
+                Return Entry.Value.ToString
+                'MessageBox.Show(Entry.Value.ToString)
+
+            End If
+
+        Next
     End Function
 
     Public Shared Function GetManifests() As String

--- a/libguinget/PackageListTools.vb
+++ b/libguinget/PackageListTools.vb
@@ -46,31 +46,35 @@ Public Class PackageListTools
         ' This working example is described in the following
         ' StackOverflow answer:
         ' https://stackoverflow.com/a/46897520
-        Dim Input As StreamReader = New StreamReader(ManifestPath)
+        Using Input As StreamReader = File.OpenText(ManifestPath)
 
-        ' Load the stream in.
-        Dim YamlStream As New YamlStream
-        YamlStream.Load(Input)
+            ' Load the stream in.
+            Dim YamlStream As New YamlStream
+            YamlStream.Load(Input)
 
-        ' Create variable for root node.
-        Dim YamlRoot = CType(YamlStream.Documents(0).RootNode, YamlMappingNode)
+            ' Create variable for root node.
+            Dim YamlRoot = CType(YamlStream.Documents(0).RootNode, YamlMappingNode)
 
-        For Each Entry In YamlRoot.Children
+            For Each Entry In YamlRoot.Children
 
-            ' If the requested key exists, then use it.
-            ' This check doesn't work; maybe something
-            ' like an ordered list would be better:
-            ' https://stackoverflow.com/a/30097560
-            ' Check each entry in the YAML root node.
-            If CType(Entry.Key, YamlScalarNode).Value = RequestedKey Then
-                ' If we're looking at an ID, add it to the package list array.
+                ' If the requested key exists, then use it.
+                ' This check doesn't work; maybe something
+                ' like an ordered list would be better:
+                ' https://stackoverflow.com/a/30097560
+                ' Check each entry in the YAML root node.
+                If CType(Entry.Key, YamlScalarNode).Value = RequestedKey Then
+                    ' If we're looking at an ID, add it to the package list array.
 
-                Return Entry.Value.ToString
-                'MessageBox.Show(Entry.Value.ToString)
+                    Return Entry.Value.ToString
+                    'MessageBox.Show(Entry.Value.ToString)
 
-            End If
+                End If
 
-        Next
+            Next
+
+    End Function
+
+    Async Function GetManifestInfo(YamlInput As StreamReader, RequestedKey As String) As Task
 
     End Function
 


### PR DESCRIPTION
Instead of reading the YAML files synchronously, now they're read async to improve performance and allow the main window to be interacted with again sooner. This should also reduce the chances of Windows thinking that it's not responding, like the non-async loading would often do before.

Detailed list of changes in this PR:

- Manifest details loader is now async, but the files list loader still isn't async yet.
- Loading progressbar and statuslabel have switched places, since the progressbar doesn't change its size and look bad if the statuslabel is after it.
- Package list datagridview is now shown as soon as we're done getting the files list and adding the rows to make it look like it loaded faster.
- The main window, statusbar, and datagridview now have their `Update()` functions called sometimes so they show what's going on slightly more responsively. Still can't move or resize the window while loading the package list, unfortunately.
- If people want to, the package list can now be loaded async on startup by uncommenting some code at the bottom of the main form's file and re-compiling. The goal is to eventually allow people to enable or disable this feature at runtime, but it's turned off for now as loading the files list takes a little longer due to not being async yet.
- Datagridview is hidden before clearing its rows. Might make things look a little better on slower computers.