### PR TITLE
Allow packages to be interactively installed.

### DIFF
--- a/guinget/AboutWindow.vb
+++ b/guinget/AboutWindow.vb
@@ -35,7 +35,7 @@ Public Class AboutWindow
     Private Sub AboutWindow_Load(sender As Object, e As EventArgs) Handles MyBase.Load
         ' Put text in the About textbox.
         textboxAbout.Text = "guinget" & vbCrLf &
-                        "Version 0.1.0.1 Alpha" & vbCrLf &
+                        "Version 0.1.1 Alpha" & vbCrLf &
                         My.Application.Info.Copyright & vbCrLf &
                         vbCrLf &
                         "Unofficial GUI for Microsoft's Windows Package Manager (winget)." & vbCrLf &

--- a/guinget/App.config
+++ b/guinget/App.config
@@ -22,6 +22,9 @@
       <setting name="UseBuiltinCacheUpdater" serializeAs="String">
         <value>True</value>
       </setting>
+      <setting name="InstallInteractively" serializeAs="String">
+        <value>False</value>
+      </setting>
     </guinget.My.MySettings>
   </userSettings>
 </configuration>

--- a/guinget/ApplyChangesWindow.Designer.vb
+++ b/guinget/ApplyChangesWindow.Designer.vb
@@ -22,6 +22,7 @@ Partial Class ApplyChangesWindow
     'Do not modify it using the code editor.
     <System.Diagnostics.DebuggerStepThrough()> _
     Private Sub InitializeComponent()
+        Me.components = New System.ComponentModel.Container()
         Me.tablelayoutpanelApplyChanges = New System.Windows.Forms.TableLayoutPanel()
         Me.datagridviewAppsBeingInstalled = New System.Windows.Forms.DataGridView()
         Me.PackageName = New System.Windows.Forms.DataGridViewTextBoxColumn()
@@ -30,7 +31,8 @@ Partial Class ApplyChangesWindow
         Me.PackageCurrentStatus = New System.Windows.Forms.DataGridViewTextBoxColumn()
         Me.buttonCancel = New System.Windows.Forms.Button()
         Me.buttonConfirmChanges = New System.Windows.Forms.Button()
-        Me.CheckBox1 = New System.Windows.Forms.CheckBox()
+        Me.checkboxInstallInteractively = New System.Windows.Forms.CheckBox()
+        Me.tooltipInstallInteractively = New System.Windows.Forms.ToolTip(Me.components)
         Me.tablelayoutpanelApplyChanges.SuspendLayout()
         CType(Me.datagridviewAppsBeingInstalled, System.ComponentModel.ISupportInitialize).BeginInit()
         Me.SuspendLayout()
@@ -38,14 +40,14 @@ Partial Class ApplyChangesWindow
         'tablelayoutpanelApplyChanges
         '
         Me.tablelayoutpanelApplyChanges.ColumnCount = 4
-        Me.tablelayoutpanelApplyChanges.ColumnStyles.Add(New System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 48.0!))
+        Me.tablelayoutpanelApplyChanges.ColumnStyles.Add(New System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 179.0!))
         Me.tablelayoutpanelApplyChanges.ColumnStyles.Add(New System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100.0!))
         Me.tablelayoutpanelApplyChanges.ColumnStyles.Add(New System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 131.0!))
         Me.tablelayoutpanelApplyChanges.ColumnStyles.Add(New System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 112.0!))
         Me.tablelayoutpanelApplyChanges.Controls.Add(Me.datagridviewAppsBeingInstalled, 0, 0)
         Me.tablelayoutpanelApplyChanges.Controls.Add(Me.buttonCancel, 3, 1)
         Me.tablelayoutpanelApplyChanges.Controls.Add(Me.buttonConfirmChanges, 2, 1)
-        Me.tablelayoutpanelApplyChanges.Controls.Add(Me.CheckBox1, 0, 1)
+        Me.tablelayoutpanelApplyChanges.Controls.Add(Me.checkboxInstallInteractively, 0, 1)
         Me.tablelayoutpanelApplyChanges.Dock = System.Windows.Forms.DockStyle.Fill
         Me.tablelayoutpanelApplyChanges.Location = New System.Drawing.Point(0, 0)
         Me.tablelayoutpanelApplyChanges.Margin = New System.Windows.Forms.Padding(2)
@@ -136,16 +138,17 @@ Partial Class ApplyChangesWindow
         Me.buttonConfirmChanges.Text = "Confirm changes"
         Me.buttonConfirmChanges.UseVisualStyleBackColor = True
         '
-        'CheckBox1
+        'checkboxInstallInteractively
         '
-        Me.CheckBox1.AutoSize = True
-        Me.CheckBox1.Dock = System.Windows.Forms.DockStyle.Fill
-        Me.CheckBox1.Location = New System.Drawing.Point(3, 421)
-        Me.CheckBox1.Name = "CheckBox1"
-        Me.CheckBox1.Size = New System.Drawing.Size(42, 34)
-        Me.CheckBox1.TabIndex = 3
-        Me.CheckBox1.Text = "-i"
-        Me.CheckBox1.UseVisualStyleBackColor = True
+        Me.checkboxInstallInteractively.AutoSize = True
+        Me.checkboxInstallInteractively.Dock = System.Windows.Forms.DockStyle.Fill
+        Me.checkboxInstallInteractively.Location = New System.Drawing.Point(3, 421)
+        Me.checkboxInstallInteractively.Name = "checkboxInstallInteractively"
+        Me.checkboxInstallInteractively.Size = New System.Drawing.Size(173, 34)
+        Me.checkboxInstallInteractively.TabIndex = 3
+        Me.checkboxInstallInteractively.Text = "Install interactively (-i)"
+        Me.tooltipInstallInteractively.SetToolTip(Me.checkboxInstallInteractively, "Packages will be installed interactively when checked.")
+        Me.checkboxInstallInteractively.UseVisualStyleBackColor = True
         '
         'ApplyChangesWindow
         '
@@ -175,5 +178,6 @@ Partial Class ApplyChangesWindow
     Friend WithEvents PackageVersion As DataGridViewTextBoxColumn
     Friend WithEvents PackageAction As DataGridViewTextBoxColumn
     Friend WithEvents PackageCurrentStatus As DataGridViewTextBoxColumn
-    Friend WithEvents CheckBox1 As CheckBox
+    Friend WithEvents checkboxInstallInteractively As CheckBox
+    Friend WithEvents tooltipInstallInteractively As ToolTip
 End Class

--- a/guinget/ApplyChangesWindow.Designer.vb
+++ b/guinget/ApplyChangesWindow.Designer.vb
@@ -30,19 +30,22 @@ Partial Class ApplyChangesWindow
         Me.PackageCurrentStatus = New System.Windows.Forms.DataGridViewTextBoxColumn()
         Me.buttonCancel = New System.Windows.Forms.Button()
         Me.buttonConfirmChanges = New System.Windows.Forms.Button()
+        Me.CheckBox1 = New System.Windows.Forms.CheckBox()
         Me.tablelayoutpanelApplyChanges.SuspendLayout()
         CType(Me.datagridviewAppsBeingInstalled, System.ComponentModel.ISupportInitialize).BeginInit()
         Me.SuspendLayout()
         '
         'tablelayoutpanelApplyChanges
         '
-        Me.tablelayoutpanelApplyChanges.ColumnCount = 3
+        Me.tablelayoutpanelApplyChanges.ColumnCount = 4
+        Me.tablelayoutpanelApplyChanges.ColumnStyles.Add(New System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 48.0!))
         Me.tablelayoutpanelApplyChanges.ColumnStyles.Add(New System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100.0!))
         Me.tablelayoutpanelApplyChanges.ColumnStyles.Add(New System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 131.0!))
         Me.tablelayoutpanelApplyChanges.ColumnStyles.Add(New System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 112.0!))
         Me.tablelayoutpanelApplyChanges.Controls.Add(Me.datagridviewAppsBeingInstalled, 0, 0)
-        Me.tablelayoutpanelApplyChanges.Controls.Add(Me.buttonCancel, 2, 1)
-        Me.tablelayoutpanelApplyChanges.Controls.Add(Me.buttonConfirmChanges, 1, 1)
+        Me.tablelayoutpanelApplyChanges.Controls.Add(Me.buttonCancel, 3, 1)
+        Me.tablelayoutpanelApplyChanges.Controls.Add(Me.buttonConfirmChanges, 2, 1)
+        Me.tablelayoutpanelApplyChanges.Controls.Add(Me.CheckBox1, 0, 1)
         Me.tablelayoutpanelApplyChanges.Dock = System.Windows.Forms.DockStyle.Fill
         Me.tablelayoutpanelApplyChanges.Location = New System.Drawing.Point(0, 0)
         Me.tablelayoutpanelApplyChanges.Margin = New System.Windows.Forms.Padding(2)
@@ -63,7 +66,7 @@ Partial Class ApplyChangesWindow
         Me.datagridviewAppsBeingInstalled.BackgroundColor = System.Drawing.SystemColors.Window
         Me.datagridviewAppsBeingInstalled.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize
         Me.datagridviewAppsBeingInstalled.Columns.AddRange(New System.Windows.Forms.DataGridViewColumn() {Me.PackageName, Me.PackageVersion, Me.PackageAction, Me.PackageCurrentStatus})
-        Me.tablelayoutpanelApplyChanges.SetColumnSpan(Me.datagridviewAppsBeingInstalled, 3)
+        Me.tablelayoutpanelApplyChanges.SetColumnSpan(Me.datagridviewAppsBeingInstalled, 4)
         Me.datagridviewAppsBeingInstalled.Dock = System.Windows.Forms.DockStyle.Fill
         Me.datagridviewAppsBeingInstalled.Location = New System.Drawing.Point(2, 2)
         Me.datagridviewAppsBeingInstalled.Margin = New System.Windows.Forms.Padding(2)
@@ -133,6 +136,19 @@ Partial Class ApplyChangesWindow
         Me.buttonConfirmChanges.Text = "Confirm changes"
         Me.buttonConfirmChanges.UseVisualStyleBackColor = True
         '
+        'CheckBox1
+        '
+        Me.CheckBox1.Anchor = CType((((System.Windows.Forms.AnchorStyles.Top Or System.Windows.Forms.AnchorStyles.Bottom) _
+            Or System.Windows.Forms.AnchorStyles.Left) _
+            Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)
+        Me.CheckBox1.AutoSize = True
+        Me.CheckBox1.Location = New System.Drawing.Point(3, 421)
+        Me.CheckBox1.Name = "CheckBox1"
+        Me.CheckBox1.Size = New System.Drawing.Size(42, 34)
+        Me.CheckBox1.TabIndex = 3
+        Me.CheckBox1.Text = "-i"
+        Me.CheckBox1.UseVisualStyleBackColor = True
+        '
         'ApplyChangesWindow
         '
         Me.AutoScaleDimensions = New System.Drawing.SizeF(120.0!, 120.0!)
@@ -147,6 +163,7 @@ Partial Class ApplyChangesWindow
         Me.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent
         Me.Text = "Apply changes"
         Me.tablelayoutpanelApplyChanges.ResumeLayout(False)
+        Me.tablelayoutpanelApplyChanges.PerformLayout()
         CType(Me.datagridviewAppsBeingInstalled, System.ComponentModel.ISupportInitialize).EndInit()
         Me.ResumeLayout(False)
 
@@ -160,4 +177,5 @@ Partial Class ApplyChangesWindow
     Friend WithEvents PackageVersion As DataGridViewTextBoxColumn
     Friend WithEvents PackageAction As DataGridViewTextBoxColumn
     Friend WithEvents PackageCurrentStatus As DataGridViewTextBoxColumn
+    Friend WithEvents CheckBox1 As CheckBox
 End Class

--- a/guinget/ApplyChangesWindow.Designer.vb
+++ b/guinget/ApplyChangesWindow.Designer.vb
@@ -66,7 +66,8 @@ Partial Class ApplyChangesWindow
         Me.datagridviewAppsBeingInstalled.AllowUserToResizeRows = False
         Me.datagridviewAppsBeingInstalled.AutoSizeColumnsMode = System.Windows.Forms.DataGridViewAutoSizeColumnsMode.Fill
         Me.datagridviewAppsBeingInstalled.BackgroundColor = System.Drawing.SystemColors.Window
-        Me.datagridviewAppsBeingInstalled.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize
+        Me.datagridviewAppsBeingInstalled.ColumnHeadersHeight = 29
+        Me.datagridviewAppsBeingInstalled.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.DisableResizing
         Me.datagridviewAppsBeingInstalled.Columns.AddRange(New System.Windows.Forms.DataGridViewColumn() {Me.PackageName, Me.PackageVersion, Me.PackageAction, Me.PackageCurrentStatus})
         Me.tablelayoutpanelApplyChanges.SetColumnSpan(Me.datagridviewAppsBeingInstalled, 4)
         Me.datagridviewAppsBeingInstalled.Dock = System.Windows.Forms.DockStyle.Fill

--- a/guinget/ApplyChangesWindow.Designer.vb
+++ b/guinget/ApplyChangesWindow.Designer.vb
@@ -138,10 +138,8 @@ Partial Class ApplyChangesWindow
         '
         'CheckBox1
         '
-        Me.CheckBox1.Anchor = CType((((System.Windows.Forms.AnchorStyles.Top Or System.Windows.Forms.AnchorStyles.Bottom) _
-            Or System.Windows.Forms.AnchorStyles.Left) _
-            Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)
         Me.CheckBox1.AutoSize = True
+        Me.CheckBox1.Dock = System.Windows.Forms.DockStyle.Fill
         Me.CheckBox1.Location = New System.Drawing.Point(3, 421)
         Me.CheckBox1.Name = "CheckBox1"
         Me.CheckBox1.Size = New System.Drawing.Size(42, 34)

--- a/guinget/ApplyChangesWindow.resx
+++ b/guinget/ApplyChangesWindow.resx
@@ -129,6 +129,9 @@
   <metadata name="PackageCurrentStatus.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
+  <metadata name="tooltipInstallInteractively.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
   <metadata name="PackageName.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>

--- a/guinget/ApplyChangesWindow.resx
+++ b/guinget/ApplyChangesWindow.resx
@@ -132,16 +132,7 @@
   <metadata name="tooltipInstallInteractively.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
-  <metadata name="PackageName.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="PackageVersion.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="PackageAction.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="PackageCurrentStatus.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
+  <metadata name="tooltipInstallInteractively.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
   </metadata>
 </root>

--- a/guinget/ApplyChangesWindow.vb
+++ b/guinget/ApplyChangesWindow.vb
@@ -67,7 +67,8 @@ Public Class ApplyChangesWindow
                 ' for now until configuration is possible and until we display winget output
                 ' in a textbox below the datagridview.
                 PackageTools.InstallPkg(datagridviewAppsBeingInstalled.CurrentRow.Cells.Item(0).Value.ToString,
-                                                   datagridviewAppsBeingInstalled.CurrentRow.Cells.Item(1).Value.ToString)
+                                        datagridviewAppsBeingInstalled.CurrentRow.Cells.Item(1).Value.ToString,
+                                        My.Settings.InstallInteractively)
 
             End If
         End If

--- a/guinget/ApplyChangesWindow.vb
+++ b/guinget/ApplyChangesWindow.vb
@@ -82,4 +82,11 @@ Public Class ApplyChangesWindow
 
         End If
     End Sub
+
+    Private Sub checkboxInstallInteractively_CheckedChanged(sender As Object, e As EventArgs) Handles checkboxInstallInteractively.CheckedChanged
+        ' Update the setting for interactive installation so the value persists.
+        My.Settings.InstallInteractively = checkboxInstallInteractively.Checked
+        My.Settings.Save()
+        My.Settings.Reload()
+    End Sub
 End Class

--- a/guinget/ApplyChangesWindow.vb
+++ b/guinget/ApplyChangesWindow.vb
@@ -89,4 +89,9 @@ Public Class ApplyChangesWindow
         My.Settings.Save()
         My.Settings.Reload()
     End Sub
+
+    Private Sub ApplyChangesWindow_Load(sender As Object, e As EventArgs) Handles MyBase.Load
+        ' Match the install interactively checkbox check state to the setting.
+        checkboxInstallInteractively.Checked = My.Settings.InstallInteractively
+    End Sub
 End Class

--- a/guinget/MainWindow.Designer.vb
+++ b/guinget/MainWindow.Designer.vb
@@ -23,9 +23,9 @@ Partial Class aaformMainWindow
     <System.Diagnostics.DebuggerStepThrough()>
     Private Sub InitializeComponent()
         Me.components = New System.ComponentModel.Container()
-        Dim DataGridViewCellStyle1 As System.Windows.Forms.DataGridViewCellStyle = New System.Windows.Forms.DataGridViewCellStyle()
-        Dim DataGridViewCellStyle2 As System.Windows.Forms.DataGridViewCellStyle = New System.Windows.Forms.DataGridViewCellStyle()
-        Dim DataGridViewCellStyle3 As System.Windows.Forms.DataGridViewCellStyle = New System.Windows.Forms.DataGridViewCellStyle()
+        Dim DataGridViewCellStyle4 As System.Windows.Forms.DataGridViewCellStyle = New System.Windows.Forms.DataGridViewCellStyle()
+        Dim DataGridViewCellStyle5 As System.Windows.Forms.DataGridViewCellStyle = New System.Windows.Forms.DataGridViewCellStyle()
+        Dim DataGridViewCellStyle6 As System.Windows.Forms.DataGridViewCellStyle = New System.Windows.Forms.DataGridViewCellStyle()
         Dim resources As System.ComponentModel.ComponentResourceManager = New System.ComponentModel.ComponentResourceManager(GetType(aaformMainWindow))
         Me.menustripMainWindow = New System.Windows.Forms.MenuStrip()
         Me.FileToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
@@ -299,37 +299,37 @@ Partial Class aaformMainWindow
         Me.datagridviewPackageList.AllowUserToResizeRows = False
         Me.datagridviewPackageList.AutoSizeColumnsMode = System.Windows.Forms.DataGridViewAutoSizeColumnsMode.Fill
         Me.datagridviewPackageList.BackgroundColor = System.Drawing.SystemColors.Window
-        DataGridViewCellStyle1.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft
-        DataGridViewCellStyle1.BackColor = System.Drawing.SystemColors.Control
-        DataGridViewCellStyle1.Font = New System.Drawing.Font("Microsoft Sans Serif", 7.8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
-        DataGridViewCellStyle1.ForeColor = System.Drawing.SystemColors.WindowText
-        DataGridViewCellStyle1.SelectionBackColor = System.Drawing.SystemColors.Highlight
-        DataGridViewCellStyle1.SelectionForeColor = System.Drawing.SystemColors.HighlightText
-        DataGridViewCellStyle1.WrapMode = System.Windows.Forms.DataGridViewTriState.[True]
-        Me.datagridviewPackageList.ColumnHeadersDefaultCellStyle = DataGridViewCellStyle1
+        DataGridViewCellStyle4.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft
+        DataGridViewCellStyle4.BackColor = System.Drawing.SystemColors.Control
+        DataGridViewCellStyle4.Font = New System.Drawing.Font("Microsoft Sans Serif", 7.8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
+        DataGridViewCellStyle4.ForeColor = System.Drawing.SystemColors.WindowText
+        DataGridViewCellStyle4.SelectionBackColor = System.Drawing.SystemColors.Highlight
+        DataGridViewCellStyle4.SelectionForeColor = System.Drawing.SystemColors.HighlightText
+        DataGridViewCellStyle4.WrapMode = System.Windows.Forms.DataGridViewTriState.[True]
+        Me.datagridviewPackageList.ColumnHeadersDefaultCellStyle = DataGridViewCellStyle4
         Me.datagridviewPackageList.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize
         Me.datagridviewPackageList.Columns.AddRange(New System.Windows.Forms.DataGridViewColumn() {Me.PkgAction, Me.PkgStatus, Me.PkgName, Me.FriendlyName, Me.AvailableVersion, Me.PkgDescription, Me.Manifest})
         Me.datagridviewPackageList.ContextMenuStrip = Me.contextmenustripPackageMenu
-        DataGridViewCellStyle2.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft
-        DataGridViewCellStyle2.BackColor = System.Drawing.SystemColors.Window
-        DataGridViewCellStyle2.Font = New System.Drawing.Font("Microsoft Sans Serif", 7.8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
-        DataGridViewCellStyle2.ForeColor = System.Drawing.SystemColors.ControlText
-        DataGridViewCellStyle2.SelectionBackColor = System.Drawing.SystemColors.Highlight
-        DataGridViewCellStyle2.SelectionForeColor = System.Drawing.SystemColors.HighlightText
-        DataGridViewCellStyle2.WrapMode = System.Windows.Forms.DataGridViewTriState.[False]
-        Me.datagridviewPackageList.DefaultCellStyle = DataGridViewCellStyle2
+        DataGridViewCellStyle5.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft
+        DataGridViewCellStyle5.BackColor = System.Drawing.SystemColors.Window
+        DataGridViewCellStyle5.Font = New System.Drawing.Font("Microsoft Sans Serif", 7.8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
+        DataGridViewCellStyle5.ForeColor = System.Drawing.SystemColors.ControlText
+        DataGridViewCellStyle5.SelectionBackColor = System.Drawing.SystemColors.Highlight
+        DataGridViewCellStyle5.SelectionForeColor = System.Drawing.SystemColors.HighlightText
+        DataGridViewCellStyle5.WrapMode = System.Windows.Forms.DataGridViewTriState.[False]
+        Me.datagridviewPackageList.DefaultCellStyle = DataGridViewCellStyle5
         Me.datagridviewPackageList.Dock = System.Windows.Forms.DockStyle.Fill
         Me.datagridviewPackageList.Location = New System.Drawing.Point(0, 0)
         Me.datagridviewPackageList.Margin = New System.Windows.Forms.Padding(2)
         Me.datagridviewPackageList.Name = "datagridviewPackageList"
-        DataGridViewCellStyle3.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft
-        DataGridViewCellStyle3.BackColor = System.Drawing.SystemColors.Control
-        DataGridViewCellStyle3.Font = New System.Drawing.Font("Microsoft Sans Serif", 7.8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
-        DataGridViewCellStyle3.ForeColor = System.Drawing.SystemColors.WindowText
-        DataGridViewCellStyle3.SelectionBackColor = System.Drawing.SystemColors.Highlight
-        DataGridViewCellStyle3.SelectionForeColor = System.Drawing.SystemColors.HighlightText
-        DataGridViewCellStyle3.WrapMode = System.Windows.Forms.DataGridViewTriState.[True]
-        Me.datagridviewPackageList.RowHeadersDefaultCellStyle = DataGridViewCellStyle3
+        DataGridViewCellStyle6.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft
+        DataGridViewCellStyle6.BackColor = System.Drawing.SystemColors.Control
+        DataGridViewCellStyle6.Font = New System.Drawing.Font("Microsoft Sans Serif", 7.8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
+        DataGridViewCellStyle6.ForeColor = System.Drawing.SystemColors.WindowText
+        DataGridViewCellStyle6.SelectionBackColor = System.Drawing.SystemColors.Highlight
+        DataGridViewCellStyle6.SelectionForeColor = System.Drawing.SystemColors.HighlightText
+        DataGridViewCellStyle6.WrapMode = System.Windows.Forms.DataGridViewTriState.[True]
+        Me.datagridviewPackageList.RowHeadersDefaultCellStyle = DataGridViewCellStyle6
         Me.datagridviewPackageList.RowHeadersVisible = False
         Me.datagridviewPackageList.RowHeadersWidth = 51
         Me.datagridviewPackageList.RowTemplate.Height = 24
@@ -615,7 +615,7 @@ Partial Class aaformMainWindow
         Me.tabpageStatus.Margin = New System.Windows.Forms.Padding(2)
         Me.tabpageStatus.Name = "tabpageStatus"
         Me.tabpageStatus.Padding = New System.Windows.Forms.Padding(2)
-        Me.tabpageStatus.Size = New System.Drawing.Size(288, 508)
+        Me.tabpageStatus.Size = New System.Drawing.Size(288, 514)
         Me.tabpageStatus.TabIndex = 1
         Me.tabpageStatus.Text = "Status"
         Me.tabpageStatus.UseVisualStyleBackColor = True
@@ -630,7 +630,7 @@ Partial Class aaformMainWindow
         Me.listboxStatusTab.Location = New System.Drawing.Point(2, 2)
         Me.listboxStatusTab.Margin = New System.Windows.Forms.Padding(2)
         Me.listboxStatusTab.Name = "listboxStatusTab"
-        Me.listboxStatusTab.Size = New System.Drawing.Size(284, 504)
+        Me.listboxStatusTab.Size = New System.Drawing.Size(284, 510)
         Me.listboxStatusTab.TabIndex = 0
         '
         'tabpageCustomFilters
@@ -639,7 +639,7 @@ Partial Class aaformMainWindow
         Me.tabpageCustomFilters.Location = New System.Drawing.Point(4, 25)
         Me.tabpageCustomFilters.Margin = New System.Windows.Forms.Padding(2)
         Me.tabpageCustomFilters.Name = "tabpageCustomFilters"
-        Me.tabpageCustomFilters.Size = New System.Drawing.Size(288, 508)
+        Me.tabpageCustomFilters.Size = New System.Drawing.Size(288, 514)
         Me.tabpageCustomFilters.TabIndex = 3
         Me.tabpageCustomFilters.Text = "Custom filters"
         Me.tabpageCustomFilters.UseVisualStyleBackColor = True
@@ -654,7 +654,7 @@ Partial Class aaformMainWindow
         Me.listboxCustomFilters.Location = New System.Drawing.Point(0, 0)
         Me.listboxCustomFilters.Margin = New System.Windows.Forms.Padding(2)
         Me.listboxCustomFilters.Name = "listboxCustomFilters"
-        Me.listboxCustomFilters.Size = New System.Drawing.Size(288, 508)
+        Me.listboxCustomFilters.Size = New System.Drawing.Size(288, 514)
         Me.listboxCustomFilters.TabIndex = 1
         '
         'tabpageSections
@@ -664,7 +664,7 @@ Partial Class aaformMainWindow
         Me.tabpageSections.Margin = New System.Windows.Forms.Padding(2)
         Me.tabpageSections.Name = "tabpageSections"
         Me.tabpageSections.Padding = New System.Windows.Forms.Padding(2)
-        Me.tabpageSections.Size = New System.Drawing.Size(288, 508)
+        Me.tabpageSections.Size = New System.Drawing.Size(288, 514)
         Me.tabpageSections.TabIndex = 0
         Me.tabpageSections.Text = "Categories"
         Me.tabpageSections.UseVisualStyleBackColor = True
@@ -679,7 +679,7 @@ Partial Class aaformMainWindow
         Me.listboxSections.Location = New System.Drawing.Point(2, 2)
         Me.listboxSections.Margin = New System.Windows.Forms.Padding(2)
         Me.listboxSections.Name = "listboxSections"
-        Me.listboxSections.Size = New System.Drawing.Size(284, 504)
+        Me.listboxSections.Size = New System.Drawing.Size(284, 510)
         Me.listboxSections.TabIndex = 1
         '
         'tabpageSource
@@ -688,7 +688,7 @@ Partial Class aaformMainWindow
         Me.tabpageSource.Location = New System.Drawing.Point(4, 25)
         Me.tabpageSource.Margin = New System.Windows.Forms.Padding(2)
         Me.tabpageSource.Name = "tabpageSource"
-        Me.tabpageSource.Size = New System.Drawing.Size(288, 508)
+        Me.tabpageSource.Size = New System.Drawing.Size(288, 514)
         Me.tabpageSource.TabIndex = 2
         Me.tabpageSource.Text = "Source"
         Me.tabpageSource.UseVisualStyleBackColor = True
@@ -703,7 +703,7 @@ Partial Class aaformMainWindow
         Me.listboxSourceTab.Location = New System.Drawing.Point(0, 0)
         Me.listboxSourceTab.Margin = New System.Windows.Forms.Padding(2)
         Me.listboxSourceTab.Name = "listboxSourceTab"
-        Me.listboxSourceTab.Size = New System.Drawing.Size(288, 508)
+        Me.listboxSourceTab.Size = New System.Drawing.Size(288, 514)
         Me.listboxSourceTab.TabIndex = 1
         '
         'tabpageArchitecture
@@ -712,7 +712,7 @@ Partial Class aaformMainWindow
         Me.tabpageArchitecture.Location = New System.Drawing.Point(4, 25)
         Me.tabpageArchitecture.Margin = New System.Windows.Forms.Padding(2)
         Me.tabpageArchitecture.Name = "tabpageArchitecture"
-        Me.tabpageArchitecture.Size = New System.Drawing.Size(288, 508)
+        Me.tabpageArchitecture.Size = New System.Drawing.Size(288, 514)
         Me.tabpageArchitecture.TabIndex = 5
         Me.tabpageArchitecture.Text = "Architecture"
         Me.tabpageArchitecture.UseVisualStyleBackColor = True
@@ -727,7 +727,7 @@ Partial Class aaformMainWindow
         Me.listboxArchitecture.Location = New System.Drawing.Point(0, 0)
         Me.listboxArchitecture.Margin = New System.Windows.Forms.Padding(2)
         Me.listboxArchitecture.Name = "listboxArchitecture"
-        Me.listboxArchitecture.Size = New System.Drawing.Size(288, 508)
+        Me.listboxArchitecture.Size = New System.Drawing.Size(288, 514)
         Me.listboxArchitecture.TabIndex = 1
         '
         'panelMainForm
@@ -788,7 +788,7 @@ Partial Class aaformMainWindow
         Me.MainMenuStrip = Me.menustripMainWindow
         Me.Margin = New System.Windows.Forms.Padding(2)
         Me.Name = "aaformMainWindow"
-        Me.Text = "guinget version 0.1.0.1 alpha"
+        Me.Text = "guinget version 0.1.1 alpha"
         Me.menustripMainWindow.ResumeLayout(False)
         Me.menustripMainWindow.PerformLayout()
         Me.contextmenustripPackageMenu.ResumeLayout(False)

--- a/guinget/MainWindow.resx
+++ b/guinget/MainWindow.resx
@@ -123,6 +123,9 @@
   <metadata name="contextmenustripPackageMenu.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>357, 17</value>
   </metadata>
+  <data name="textboxPackageDetails.Text" xml:space="preserve">
+    <value>No package is selected or the package list hasn't been loaded yet. You can load the package list by using the Refresh cache toolbar button, by going to Package list&gt;Refresh cache, or by pressing Ctrl+R.</value>
+  </data>
   <metadata name="PkgAction.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
@@ -144,9 +147,6 @@
   <metadata name="Manifest.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
-  <data name="textboxPackageDetails.Text" xml:space="preserve">
-    <value>No package is selected or the package list hasn't been loaded yet. You can load the package list by using the Refresh cache toolbar button, by going to Package list&gt;Refresh cache, or by pressing Ctrl+R.</value>
-  </data>
   <metadata name="toolstripMainWindow.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>153, 17</value>
   </metadata>

--- a/guinget/My Project/AssemblyInfo.vb
+++ b/guinget/My Project/AssemblyInfo.vb
@@ -31,5 +31,5 @@ Imports System.Runtime.InteropServices
 ' by using the '*' as shown below:
 ' <Assembly: AssemblyVersion("1.0.*")> 
 
-<Assembly: AssemblyVersion("0.1.0.1")>
-<Assembly: AssemblyFileVersion("0.1.0.1")>
+<Assembly: AssemblyVersion("0.1.1.0")>
+<Assembly: AssemblyFileVersion("0.1.1.0")>

--- a/guinget/My Project/Settings.Designer.vb
+++ b/guinget/My Project/Settings.Designer.vb
@@ -77,6 +77,18 @@ Namespace My
                 Me("UseBuiltinCacheUpdater") = value
             End Set
         End Property
+        
+        <Global.System.Configuration.UserScopedSettingAttribute(),  _
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
+         Global.System.Configuration.DefaultSettingValueAttribute("False")>  _
+        Public Property InstallInteractively() As Boolean
+            Get
+                Return CType(Me("InstallInteractively"),Boolean)
+            End Get
+            Set
+                Me("InstallInteractively") = value
+            End Set
+        End Property
     End Class
 End Namespace
 

--- a/guinget/My Project/Settings.settings
+++ b/guinget/My Project/Settings.settings
@@ -8,5 +8,8 @@
     <Setting Name="UseBuiltinCacheUpdater" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">True</Value>
     </Setting>
+    <Setting Name="InstallInteractively" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/libguinget/My Project/AssemblyInfo.vb
+++ b/libguinget/My Project/AssemblyInfo.vb
@@ -31,5 +31,5 @@ Imports System.Runtime.InteropServices
 ' by using the '*' as shown below:
 ' <Assembly: AssemblyVersion("1.0.*")> 
 
-<Assembly: AssemblyVersion("0.1.0.1")>
-<Assembly: AssemblyFileVersion("0.1.0.1")>
+<Assembly: AssemblyVersion("0.1.1.0")>
+<Assembly: AssemblyFileVersion("0.1.1.0")>

--- a/libguinget/PackageTools.vb
+++ b/libguinget/PackageTools.vb
@@ -44,7 +44,7 @@ Public Class PackageTools
             ' Define interactive installation flag.
             Dim InteractiveFlag As String = ""
             If InstallInteractively = True Then
-                InteractiveFlag = " -i "
+                InteractiveFlag = " -i"
             End If
 
             ' Define CMD args.

--- a/libguinget/PackageTools.vb
+++ b/libguinget/PackageTools.vb
@@ -31,7 +31,6 @@ Imports YamlDotNet.RepresentationModel
 Public Class PackageTools
 
 #Region "Install package with winget."
-
     Public Shared Sub InstallPkg(PackageId As String, PackageVersion As String, Optional InstallInteractively As Boolean = False)
 
         ' Define variables for storing the winget process. We'll run CMD
@@ -55,7 +54,6 @@ Public Class PackageTools
         End Using
 
     End Sub
-
 #End Region
 
 #Region "Get package details from YAML"

--- a/libguinget/PackageTools.vb
+++ b/libguinget/PackageTools.vb
@@ -32,7 +32,7 @@ Public Class PackageTools
 
 #Region "Install package with winget."
 
-    Public Shared Sub InstallPkg(PackageId As String, PackageVersion As String)
+    Public Shared Sub InstallPkg(PackageId As String, PackageVersion As String, InstallInteractively As Boolean)
 
         ' Define variables for storing the winget process. We'll run CMD
         ' so that we can keep it open with /k.
@@ -41,8 +41,14 @@ Public Class PackageTools
 
             proc.StartInfo.FileName = "cmd"
 
+            ' Define interactive installation flag.
+            Dim InteractiveFlag As String = ""
+            If InstallInteractively = True Then
+                InteractiveFlag = " -i "
+            End If
+
             ' Define CMD args.
-            proc.StartInfo.Arguments = "/k winget install --id " & PackageId & " -v " & PackageVersion & " -e"
+            proc.StartInfo.Arguments = "/k winget install --id " & PackageId & " -v " & PackageVersion & InteractiveFlag & " -e"
 
             proc.Start()
 

--- a/libguinget/PackageTools.vb
+++ b/libguinget/PackageTools.vb
@@ -32,7 +32,7 @@ Public Class PackageTools
 
 #Region "Install package with winget."
 
-    Public Shared Sub InstallPkg(PackageId As String, PackageVersion As String, InstallInteractively As Boolean)
+    Public Shared Sub InstallPkg(PackageId As String, PackageVersion As String, Optional InstallInteractively As Boolean = False)
 
         ' Define variables for storing the winget process. We'll run CMD
         ' so that we can keep it open with /k.


### PR DESCRIPTION
If the `Install interactively (-i)` checkbox in the Apply changes window is checked, packages will be installed interactively. Checking this checkbox saves to the application settings, so it persists closing and re-opening the window along with application restarts.

Additionally, the column headers in the Apply changes window are no longer taller than they should be.