### PR TITLE
Experimental latest version displayer

### DIFF
--- a/guinget/App.config
+++ b/guinget/App.config
@@ -52,6 +52,9 @@
       <setting name="DebuggingBypassCacheUpdate" serializeAs="String">
         <value>False</value>
       </setting>
+      <setting name="HideOlderPackageVersions" serializeAs="String">
+        <value>True</value>
+      </setting>
     </guinget.My.MySettings>
   </userSettings>
   <runtime>

--- a/guinget/App.config
+++ b/guinget/App.config
@@ -53,7 +53,7 @@
         <value>True</value>
       </setting>
       <setting name="OnlyDisplayLatestPackageVersion" serializeAs="String">
-        <value>True</value>
+        <value>False</value>
       </setting>
     </guinget.My.MySettings>
   </userSettings>

--- a/guinget/App.config
+++ b/guinget/App.config
@@ -53,7 +53,7 @@
         <value>False</value>
       </setting>
       <setting name="OnlyDisplayLatestPackageVersion" serializeAs="String">
-        <value>True</value>
+        <value>False</value>
       </setting>
     </guinget.My.MySettings>
   </userSettings>

--- a/guinget/App.config
+++ b/guinget/App.config
@@ -52,7 +52,7 @@
       <setting name="DebuggingBypassCacheUpdate" serializeAs="String">
         <value>False</value>
       </setting>
-      <setting name="HideOlderPackageVersions" serializeAs="String">
+      <setting name="OnlyDisplayLatestPackageVersion" serializeAs="String">
         <value>True</value>
       </setting>
     </guinget.My.MySettings>

--- a/guinget/App.config
+++ b/guinget/App.config
@@ -50,7 +50,7 @@
         <value>True</value>
       </setting>
       <setting name="DebuggingBypassCacheUpdate" serializeAs="String">
-        <value>True</value>
+        <value>False</value>
       </setting>
       <setting name="OnlyDisplayLatestPackageVersion" serializeAs="String">
         <value>False</value>

--- a/guinget/App.config
+++ b/guinget/App.config
@@ -50,10 +50,10 @@
         <value>True</value>
       </setting>
       <setting name="DebuggingBypassCacheUpdate" serializeAs="String">
-        <value>False</value>
+        <value>True</value>
       </setting>
       <setting name="OnlyDisplayLatestPackageVersion" serializeAs="String">
-        <value>False</value>
+        <value>True</value>
       </setting>
     </guinget.My.MySettings>
   </userSettings>

--- a/guinget/MainWindow.Designer.vb
+++ b/guinget/MainWindow.Designer.vb
@@ -60,14 +60,6 @@ Partial Class aaformMainWindow
         Me.splitcontainerMainWindow = New System.Windows.Forms.SplitContainer()
         Me.panelPackageListHolder = New System.Windows.Forms.Panel()
         Me.datagridviewPackageList = New System.Windows.Forms.DataGridView()
-        Me.PkgAction = New System.Windows.Forms.DataGridViewComboBoxColumn()
-        Me.PkgStatus = New System.Windows.Forms.DataGridViewTextBoxColumn()
-        Me.PkgName = New System.Windows.Forms.DataGridViewTextBoxColumn()
-        Me.FriendlyName = New System.Windows.Forms.DataGridViewTextBoxColumn()
-        Me.AvailableVersion = New System.Windows.Forms.DataGridViewTextBoxColumn()
-        Me.LatestVersion = New System.Windows.Forms.DataGridViewTextBoxColumn()
-        Me.PkgDescription = New System.Windows.Forms.DataGridViewTextBoxColumn()
-        Me.Manifest = New System.Windows.Forms.DataGridViewTextBoxColumn()
         Me.labelUpdatingPackageList = New System.Windows.Forms.Label()
         Me.textboxPackageDetails = New System.Windows.Forms.TextBox()
         Me.panelMainPkgArea = New System.Windows.Forms.Panel()
@@ -110,6 +102,14 @@ Partial Class aaformMainWindow
         Me.SelectedPackageToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
         Me.zCantFindThisPackagePropertiesMenuItem = New System.Windows.Forms.ToolStripMenuItem()
         Me.zSeparatorNoIdeaWhereThisIs = New System.Windows.Forms.ToolStripSeparator()
+        Me.PkgAction = New System.Windows.Forms.DataGridViewComboBoxColumn()
+        Me.PkgStatus = New System.Windows.Forms.DataGridViewTextBoxColumn()
+        Me.PkgName = New System.Windows.Forms.DataGridViewTextBoxColumn()
+        Me.FriendlyName = New System.Windows.Forms.DataGridViewTextBoxColumn()
+        Me.AvailableVersion = New System.Windows.Forms.DataGridViewTextBoxColumn()
+        Me.LatestVersion = New System.Windows.Forms.DataGridViewTextBoxColumn()
+        Me.PkgDescription = New System.Windows.Forms.DataGridViewTextBoxColumn()
+        Me.Manifest = New System.Windows.Forms.DataGridViewTextBoxColumn()
         Me.menustripMainWindow.SuspendLayout()
         Me.contextmenustripPackageMenu.SuspendLayout()
         CType(Me.splitcontainerMainWindow, System.ComponentModel.ISupportInitialize).BeginInit()
@@ -411,71 +411,6 @@ Partial Class aaformMainWindow
         Me.datagridviewPackageList.Size = New System.Drawing.Size(829, 427)
         Me.datagridviewPackageList.StandardTab = True
         Me.datagridviewPackageList.TabIndex = 0
-        '
-        'PkgAction
-        '
-        Me.PkgAction.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCells
-        Me.PkgAction.HeaderText = "Action"
-        Me.PkgAction.Items.AddRange(New Object() {"Do nothing", "Install"})
-        Me.PkgAction.MinimumWidth = 6
-        Me.PkgAction.Name = "PkgAction"
-        Me.PkgAction.ReadOnly = True
-        Me.PkgAction.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Automatic
-        Me.PkgAction.Width = 76
-        '
-        'PkgStatus
-        '
-        Me.PkgStatus.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCells
-        Me.PkgStatus.HeaderText = "Status"
-        Me.PkgStatus.MinimumWidth = 6
-        Me.PkgStatus.Name = "PkgStatus"
-        Me.PkgStatus.ReadOnly = True
-        Me.PkgStatus.Width = 77
-        '
-        'PkgName
-        '
-        Me.PkgName.HeaderText = "Package"
-        Me.PkgName.MinimumWidth = 6
-        Me.PkgName.Name = "PkgName"
-        Me.PkgName.ReadOnly = True
-        '
-        'FriendlyName
-        '
-        Me.FriendlyName.HeaderText = "Name"
-        Me.FriendlyName.MinimumWidth = 6
-        Me.FriendlyName.Name = "FriendlyName"
-        Me.FriendlyName.ReadOnly = True
-        '
-        'AvailableVersion
-        '
-        Me.AvailableVersion.HeaderText = "Version"
-        Me.AvailableVersion.MinimumWidth = 6
-        Me.AvailableVersion.Name = "AvailableVersion"
-        Me.AvailableVersion.ReadOnly = True
-        Me.AvailableVersion.ToolTipText = "(will eventually only display latest version and have all older versions in a win" &
-    "dow like Synaptic)"
-        '
-        'LatestVersion
-        '
-        Me.LatestVersion.HeaderText = "Latest version"
-        Me.LatestVersion.MinimumWidth = 6
-        Me.LatestVersion.Name = "LatestVersion"
-        Me.LatestVersion.ReadOnly = True
-        '
-        'PkgDescription
-        '
-        Me.PkgDescription.HeaderText = "Description"
-        Me.PkgDescription.MinimumWidth = 6
-        Me.PkgDescription.Name = "PkgDescription"
-        Me.PkgDescription.ReadOnly = True
-        '
-        'Manifest
-        '
-        Me.Manifest.HeaderText = "Manifest"
-        Me.Manifest.MinimumWidth = 6
-        Me.Manifest.Name = "Manifest"
-        Me.Manifest.ReadOnly = True
-        Me.Manifest.Visible = False
         '
         'labelUpdatingPackageList
         '
@@ -897,6 +832,72 @@ Partial Class aaformMainWindow
         '
         Me.zSeparatorNoIdeaWhereThisIs.Name = "zSeparatorNoIdeaWhereThisIs"
         Me.zSeparatorNoIdeaWhereThisIs.Size = New System.Drawing.Size(210, 6)
+        '
+        'PkgAction
+        '
+        Me.PkgAction.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCells
+        Me.PkgAction.HeaderText = "Action"
+        Me.PkgAction.Items.AddRange(New Object() {"Do nothing", "Install"})
+        Me.PkgAction.MinimumWidth = 6
+        Me.PkgAction.Name = "PkgAction"
+        Me.PkgAction.ReadOnly = True
+        Me.PkgAction.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Automatic
+        Me.PkgAction.Width = 76
+        '
+        'PkgStatus
+        '
+        Me.PkgStatus.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCells
+        Me.PkgStatus.HeaderText = "Status"
+        Me.PkgStatus.MinimumWidth = 6
+        Me.PkgStatus.Name = "PkgStatus"
+        Me.PkgStatus.ReadOnly = True
+        Me.PkgStatus.Width = 77
+        '
+        'PkgName
+        '
+        Me.PkgName.HeaderText = "Package"
+        Me.PkgName.MinimumWidth = 6
+        Me.PkgName.Name = "PkgName"
+        Me.PkgName.ReadOnly = True
+        '
+        'FriendlyName
+        '
+        Me.FriendlyName.HeaderText = "Name"
+        Me.FriendlyName.MinimumWidth = 6
+        Me.FriendlyName.Name = "FriendlyName"
+        Me.FriendlyName.ReadOnly = True
+        '
+        'AvailableVersion
+        '
+        Me.AvailableVersion.HeaderText = "Version"
+        Me.AvailableVersion.MinimumWidth = 6
+        Me.AvailableVersion.Name = "AvailableVersion"
+        Me.AvailableVersion.ReadOnly = True
+        Me.AvailableVersion.ToolTipText = "(will eventually only display latest version and have all older versions in a win" &
+    "dow like Synaptic)"
+        '
+        'LatestVersion
+        '
+        Me.LatestVersion.HeaderText = "Latest version"
+        Me.LatestVersion.MinimumWidth = 6
+        Me.LatestVersion.Name = "LatestVersion"
+        Me.LatestVersion.ReadOnly = True
+        Me.LatestVersion.Visible = False
+        '
+        'PkgDescription
+        '
+        Me.PkgDescription.HeaderText = "Description"
+        Me.PkgDescription.MinimumWidth = 6
+        Me.PkgDescription.Name = "PkgDescription"
+        Me.PkgDescription.ReadOnly = True
+        '
+        'Manifest
+        '
+        Me.Manifest.HeaderText = "Manifest"
+        Me.Manifest.MinimumWidth = 6
+        Me.Manifest.Name = "Manifest"
+        Me.Manifest.ReadOnly = True
+        Me.Manifest.Visible = False
         '
         'aaformMainWindow
         '

--- a/guinget/MainWindow.Designer.vb
+++ b/guinget/MainWindow.Designer.vb
@@ -60,6 +60,14 @@ Partial Class aaformMainWindow
         Me.splitcontainerMainWindow = New System.Windows.Forms.SplitContainer()
         Me.panelPackageListHolder = New System.Windows.Forms.Panel()
         Me.datagridviewPackageList = New System.Windows.Forms.DataGridView()
+        Me.PkgAction = New System.Windows.Forms.DataGridViewComboBoxColumn()
+        Me.PkgStatus = New System.Windows.Forms.DataGridViewTextBoxColumn()
+        Me.PkgName = New System.Windows.Forms.DataGridViewTextBoxColumn()
+        Me.FriendlyName = New System.Windows.Forms.DataGridViewTextBoxColumn()
+        Me.AvailableVersion = New System.Windows.Forms.DataGridViewTextBoxColumn()
+        Me.LatestVersion = New System.Windows.Forms.DataGridViewTextBoxColumn()
+        Me.PkgDescription = New System.Windows.Forms.DataGridViewTextBoxColumn()
+        Me.Manifest = New System.Windows.Forms.DataGridViewTextBoxColumn()
         Me.labelUpdatingPackageList = New System.Windows.Forms.Label()
         Me.textboxPackageDetails = New System.Windows.Forms.TextBox()
         Me.panelMainPkgArea = New System.Windows.Forms.Panel()
@@ -102,14 +110,6 @@ Partial Class aaformMainWindow
         Me.SelectedPackageToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
         Me.zCantFindThisPackagePropertiesMenuItem = New System.Windows.Forms.ToolStripMenuItem()
         Me.zSeparatorNoIdeaWhereThisIs = New System.Windows.Forms.ToolStripSeparator()
-        Me.PkgAction = New System.Windows.Forms.DataGridViewComboBoxColumn()
-        Me.PkgStatus = New System.Windows.Forms.DataGridViewTextBoxColumn()
-        Me.PkgName = New System.Windows.Forms.DataGridViewTextBoxColumn()
-        Me.FriendlyName = New System.Windows.Forms.DataGridViewTextBoxColumn()
-        Me.AvailableVersion = New System.Windows.Forms.DataGridViewTextBoxColumn()
-        Me.LatestVersion = New System.Windows.Forms.DataGridViewTextBoxColumn()
-        Me.PkgDescription = New System.Windows.Forms.DataGridViewTextBoxColumn()
-        Me.Manifest = New System.Windows.Forms.DataGridViewTextBoxColumn()
         Me.menustripMainWindow.SuspendLayout()
         Me.contextmenustripPackageMenu.SuspendLayout()
         CType(Me.splitcontainerMainWindow, System.ComponentModel.ISupportInitialize).BeginInit()
@@ -410,6 +410,70 @@ Partial Class aaformMainWindow
         Me.datagridviewPackageList.Size = New System.Drawing.Size(829, 427)
         Me.datagridviewPackageList.StandardTab = True
         Me.datagridviewPackageList.TabIndex = 0
+        '
+        'PkgAction
+        '
+        Me.PkgAction.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCells
+        Me.PkgAction.HeaderText = "Action"
+        Me.PkgAction.Items.AddRange(New Object() {"Do nothing", "Install"})
+        Me.PkgAction.MinimumWidth = 6
+        Me.PkgAction.Name = "PkgAction"
+        Me.PkgAction.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Automatic
+        Me.PkgAction.Width = 76
+        '
+        'PkgStatus
+        '
+        Me.PkgStatus.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCells
+        Me.PkgStatus.HeaderText = "Status"
+        Me.PkgStatus.MinimumWidth = 6
+        Me.PkgStatus.Name = "PkgStatus"
+        Me.PkgStatus.ReadOnly = True
+        Me.PkgStatus.Width = 77
+        '
+        'PkgName
+        '
+        Me.PkgName.HeaderText = "Package"
+        Me.PkgName.MinimumWidth = 6
+        Me.PkgName.Name = "PkgName"
+        Me.PkgName.ReadOnly = True
+        '
+        'FriendlyName
+        '
+        Me.FriendlyName.HeaderText = "Name"
+        Me.FriendlyName.MinimumWidth = 6
+        Me.FriendlyName.Name = "FriendlyName"
+        Me.FriendlyName.ReadOnly = True
+        '
+        'AvailableVersion
+        '
+        Me.AvailableVersion.HeaderText = "Version"
+        Me.AvailableVersion.MinimumWidth = 6
+        Me.AvailableVersion.Name = "AvailableVersion"
+        Me.AvailableVersion.ReadOnly = True
+        Me.AvailableVersion.ToolTipText = "(will eventually only display latest version and have all older versions in a win" &
+    "dow like Synaptic)"
+        '
+        'LatestVersion
+        '
+        Me.LatestVersion.HeaderText = "Latest version"
+        Me.LatestVersion.MinimumWidth = 6
+        Me.LatestVersion.Name = "LatestVersion"
+        Me.LatestVersion.ReadOnly = True
+        '
+        'PkgDescription
+        '
+        Me.PkgDescription.HeaderText = "Description"
+        Me.PkgDescription.MinimumWidth = 6
+        Me.PkgDescription.Name = "PkgDescription"
+        Me.PkgDescription.ReadOnly = True
+        '
+        'Manifest
+        '
+        Me.Manifest.HeaderText = "Manifest"
+        Me.Manifest.MinimumWidth = 6
+        Me.Manifest.Name = "Manifest"
+        Me.Manifest.ReadOnly = True
+        Me.Manifest.Visible = False
         '
         'labelUpdatingPackageList
         '
@@ -831,70 +895,6 @@ Partial Class aaformMainWindow
         '
         Me.zSeparatorNoIdeaWhereThisIs.Name = "zSeparatorNoIdeaWhereThisIs"
         Me.zSeparatorNoIdeaWhereThisIs.Size = New System.Drawing.Size(210, 6)
-        '
-        'PkgAction
-        '
-        Me.PkgAction.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCells
-        Me.PkgAction.HeaderText = "Action"
-        Me.PkgAction.Items.AddRange(New Object() {"Do nothing", "Install"})
-        Me.PkgAction.MinimumWidth = 6
-        Me.PkgAction.Name = "PkgAction"
-        Me.PkgAction.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Automatic
-        Me.PkgAction.Width = 76
-        '
-        'PkgStatus
-        '
-        Me.PkgStatus.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCells
-        Me.PkgStatus.HeaderText = "Status"
-        Me.PkgStatus.MinimumWidth = 6
-        Me.PkgStatus.Name = "PkgStatus"
-        Me.PkgStatus.ReadOnly = True
-        Me.PkgStatus.Width = 77
-        '
-        'PkgName
-        '
-        Me.PkgName.HeaderText = "Package"
-        Me.PkgName.MinimumWidth = 6
-        Me.PkgName.Name = "PkgName"
-        Me.PkgName.ReadOnly = True
-        '
-        'FriendlyName
-        '
-        Me.FriendlyName.HeaderText = "Name"
-        Me.FriendlyName.MinimumWidth = 6
-        Me.FriendlyName.Name = "FriendlyName"
-        Me.FriendlyName.ReadOnly = True
-        '
-        'AvailableVersion
-        '
-        Me.AvailableVersion.HeaderText = "Version"
-        Me.AvailableVersion.MinimumWidth = 6
-        Me.AvailableVersion.Name = "AvailableVersion"
-        Me.AvailableVersion.ReadOnly = True
-        Me.AvailableVersion.ToolTipText = "(will eventually only display latest version and have all older versions in a win" &
-    "dow like Synaptic)"
-        '
-        'LatestVersion
-        '
-        Me.LatestVersion.HeaderText = "Latest version"
-        Me.LatestVersion.MinimumWidth = 6
-        Me.LatestVersion.Name = "LatestVersion"
-        Me.LatestVersion.ReadOnly = True
-        '
-        'PkgDescription
-        '
-        Me.PkgDescription.HeaderText = "Description"
-        Me.PkgDescription.MinimumWidth = 6
-        Me.PkgDescription.Name = "PkgDescription"
-        Me.PkgDescription.ReadOnly = True
-        '
-        'Manifest
-        '
-        Me.Manifest.HeaderText = "Manifest"
-        Me.Manifest.MinimumWidth = 6
-        Me.Manifest.Name = "Manifest"
-        Me.Manifest.ReadOnly = True
-        Me.Manifest.Visible = False
         '
         'aaformMainWindow
         '

--- a/guinget/MainWindow.Designer.vb
+++ b/guinget/MainWindow.Designer.vb
@@ -394,7 +394,6 @@ Partial Class aaformMainWindow
         Me.datagridviewPackageList.Location = New System.Drawing.Point(0, 0)
         Me.datagridviewPackageList.Margin = New System.Windows.Forms.Padding(2)
         Me.datagridviewPackageList.Name = "datagridviewPackageList"
-        Me.datagridviewPackageList.ReadOnly = True
         DataGridViewCellStyle3.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft
         DataGridViewCellStyle3.BackColor = System.Drawing.SystemColors.Control
         DataGridViewCellStyle3.Font = New System.Drawing.Font("Microsoft Sans Serif", 7.8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
@@ -840,7 +839,6 @@ Partial Class aaformMainWindow
         Me.PkgAction.Items.AddRange(New Object() {"Do nothing", "Install"})
         Me.PkgAction.MinimumWidth = 6
         Me.PkgAction.Name = "PkgAction"
-        Me.PkgAction.ReadOnly = True
         Me.PkgAction.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Automatic
         Me.PkgAction.Width = 76
         '
@@ -882,7 +880,6 @@ Partial Class aaformMainWindow
         Me.LatestVersion.MinimumWidth = 6
         Me.LatestVersion.Name = "LatestVersion"
         Me.LatestVersion.ReadOnly = True
-        Me.LatestVersion.Visible = False
         '
         'PkgDescription
         '

--- a/guinget/MainWindow.Designer.vb
+++ b/guinget/MainWindow.Designer.vb
@@ -23,9 +23,9 @@ Partial Class aaformMainWindow
     <System.Diagnostics.DebuggerStepThrough()>
     Private Sub InitializeComponent()
         Me.components = New System.ComponentModel.Container()
-        Dim DataGridViewCellStyle4 As System.Windows.Forms.DataGridViewCellStyle = New System.Windows.Forms.DataGridViewCellStyle()
-        Dim DataGridViewCellStyle5 As System.Windows.Forms.DataGridViewCellStyle = New System.Windows.Forms.DataGridViewCellStyle()
-        Dim DataGridViewCellStyle6 As System.Windows.Forms.DataGridViewCellStyle = New System.Windows.Forms.DataGridViewCellStyle()
+        Dim DataGridViewCellStyle1 As System.Windows.Forms.DataGridViewCellStyle = New System.Windows.Forms.DataGridViewCellStyle()
+        Dim DataGridViewCellStyle2 As System.Windows.Forms.DataGridViewCellStyle = New System.Windows.Forms.DataGridViewCellStyle()
+        Dim DataGridViewCellStyle3 As System.Windows.Forms.DataGridViewCellStyle = New System.Windows.Forms.DataGridViewCellStyle()
         Dim resources As System.ComponentModel.ComponentResourceManager = New System.ComponentModel.ComponentResourceManager(GetType(aaformMainWindow))
         Me.menustripMainWindow = New System.Windows.Forms.MenuStrip()
         Me.FileToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
@@ -65,6 +65,7 @@ Partial Class aaformMainWindow
         Me.PkgName = New System.Windows.Forms.DataGridViewTextBoxColumn()
         Me.FriendlyName = New System.Windows.Forms.DataGridViewTextBoxColumn()
         Me.AvailableVersion = New System.Windows.Forms.DataGridViewTextBoxColumn()
+        Me.LatestVersion = New System.Windows.Forms.DataGridViewTextBoxColumn()
         Me.PkgDescription = New System.Windows.Forms.DataGridViewTextBoxColumn()
         Me.Manifest = New System.Windows.Forms.DataGridViewTextBoxColumn()
         Me.labelUpdatingPackageList = New System.Windows.Forms.Label()
@@ -142,8 +143,7 @@ Partial Class aaformMainWindow
         Me.menustripMainWindow.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.FileToolStripMenuItem, Me.ViewToolStripMenuItem, Me.PackageToolStripMenuItem, Me.SelectedPackagesToolStripMenuItem, Me.ToolsToolStripMenuItem, Me.HelpToolStripMenuItem})
         Me.menustripMainWindow.Location = New System.Drawing.Point(0, 0)
         Me.menustripMainWindow.Name = "menustripMainWindow"
-        Me.menustripMainWindow.Padding = New System.Windows.Forms.Padding(5, 2, 0, 2)
-        Me.menustripMainWindow.Size = New System.Drawing.Size(884, 24)
+        Me.menustripMainWindow.Size = New System.Drawing.Size(1105, 28)
         Me.menustripMainWindow.TabIndex = 0
         Me.menustripMainWindow.Text = "MenuStrip1"
         '
@@ -151,60 +151,60 @@ Partial Class aaformMainWindow
         '
         Me.FileToolStripMenuItem.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.ExitToolStripMenuItem})
         Me.FileToolStripMenuItem.Name = "FileToolStripMenuItem"
-        Me.FileToolStripMenuItem.Size = New System.Drawing.Size(37, 20)
+        Me.FileToolStripMenuItem.Size = New System.Drawing.Size(46, 24)
         Me.FileToolStripMenuItem.Text = "&File"
         '
         'ExitToolStripMenuItem
         '
         Me.ExitToolStripMenuItem.Name = "ExitToolStripMenuItem"
         Me.ExitToolStripMenuItem.ShortcutKeys = CType((System.Windows.Forms.Keys.Alt Or System.Windows.Forms.Keys.F4), System.Windows.Forms.Keys)
-        Me.ExitToolStripMenuItem.Size = New System.Drawing.Size(135, 22)
+        Me.ExitToolStripMenuItem.Size = New System.Drawing.Size(169, 26)
         Me.ExitToolStripMenuItem.Text = "E&xit"
         '
         'ViewToolStripMenuItem
         '
         Me.ViewToolStripMenuItem.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.SidebarToolStripMenuItem})
         Me.ViewToolStripMenuItem.Name = "ViewToolStripMenuItem"
-        Me.ViewToolStripMenuItem.Size = New System.Drawing.Size(44, 20)
+        Me.ViewToolStripMenuItem.Size = New System.Drawing.Size(55, 24)
         Me.ViewToolStripMenuItem.Text = "&View"
         '
         'SidebarToolStripMenuItem
         '
         Me.SidebarToolStripMenuItem.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None
         Me.SidebarToolStripMenuItem.Name = "SidebarToolStripMenuItem"
-        Me.SidebarToolStripMenuItem.Size = New System.Drawing.Size(180, 22)
+        Me.SidebarToolStripMenuItem.Size = New System.Drawing.Size(143, 26)
         Me.SidebarToolStripMenuItem.Text = "&Sidebar"
         '
         'PackageToolStripMenuItem
         '
         Me.PackageToolStripMenuItem.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.RefreshCacheMenuButton, Me.ApplyChangesMenuItem, Me.zSeparatorPackageListMenu, Me.SearchMenuItem, Me.AdvancedSearchMenuItem})
         Me.PackageToolStripMenuItem.Name = "PackageToolStripMenuItem"
-        Me.PackageToolStripMenuItem.Size = New System.Drawing.Size(81, 20)
+        Me.PackageToolStripMenuItem.Size = New System.Drawing.Size(100, 24)
         Me.PackageToolStripMenuItem.Text = "&Package list"
         '
         'RefreshCacheMenuButton
         '
         Me.RefreshCacheMenuButton.Name = "RefreshCacheMenuButton"
         Me.RefreshCacheMenuButton.ShortcutKeys = CType((System.Windows.Forms.Keys.Control Or System.Windows.Forms.Keys.R), System.Windows.Forms.Keys)
-        Me.RefreshCacheMenuButton.Size = New System.Drawing.Size(233, 22)
+        Me.RefreshCacheMenuButton.Size = New System.Drawing.Size(288, 26)
         Me.RefreshCacheMenuButton.Text = "&Refresh cache"
         '
         'ApplyChangesMenuItem
         '
         Me.ApplyChangesMenuItem.Name = "ApplyChangesMenuItem"
-        Me.ApplyChangesMenuItem.Size = New System.Drawing.Size(233, 22)
+        Me.ApplyChangesMenuItem.Size = New System.Drawing.Size(288, 26)
         Me.ApplyChangesMenuItem.Text = "&Apply changes..."
         '
         'zSeparatorPackageListMenu
         '
         Me.zSeparatorPackageListMenu.Name = "zSeparatorPackageListMenu"
-        Me.zSeparatorPackageListMenu.Size = New System.Drawing.Size(230, 6)
+        Me.zSeparatorPackageListMenu.Size = New System.Drawing.Size(285, 6)
         '
         'SearchMenuItem
         '
         Me.SearchMenuItem.Name = "SearchMenuItem"
         Me.SearchMenuItem.ShortcutKeys = CType((System.Windows.Forms.Keys.Control Or System.Windows.Forms.Keys.F), System.Windows.Forms.Keys)
-        Me.SearchMenuItem.Size = New System.Drawing.Size(233, 22)
+        Me.SearchMenuItem.Size = New System.Drawing.Size(288, 26)
         Me.SearchMenuItem.Text = "&Focus search box"
         '
         'AdvancedSearchMenuItem
@@ -212,82 +212,82 @@ Partial Class aaformMainWindow
         Me.AdvancedSearchMenuItem.Name = "AdvancedSearchMenuItem"
         Me.AdvancedSearchMenuItem.ShortcutKeys = CType(((System.Windows.Forms.Keys.Control Or System.Windows.Forms.Keys.Shift) _
             Or System.Windows.Forms.Keys.F), System.Windows.Forms.Keys)
-        Me.AdvancedSearchMenuItem.Size = New System.Drawing.Size(233, 22)
+        Me.AdvancedSearchMenuItem.Size = New System.Drawing.Size(288, 26)
         Me.AdvancedSearchMenuItem.Text = "Search &options..."
         '
         'SelectedPackagesToolStripMenuItem
         '
         Me.SelectedPackagesToolStripMenuItem.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.SelectedPackagesAction, Me.SelectedPackagesSearchForLastSelectedID, Me.zSeparatorSelectedPackagesMenu, Me.SelectedPackagesProperties})
         Me.SelectedPackagesToolStripMenuItem.Name = "SelectedPackagesToolStripMenuItem"
-        Me.SelectedPackagesToolStripMenuItem.Size = New System.Drawing.Size(115, 20)
+        Me.SelectedPackagesToolStripMenuItem.Size = New System.Drawing.Size(146, 24)
         Me.SelectedPackagesToolStripMenuItem.Text = "&Selected packages"
         '
         'SelectedPackagesAction
         '
         Me.SelectedPackagesAction.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.SelectedPackagesActionDoNothingMenuItem, Me.SelectedPackagesActionInstallMenuItem})
         Me.SelectedPackagesAction.Name = "SelectedPackagesAction"
-        Me.SelectedPackagesAction.Size = New System.Drawing.Size(210, 22)
+        Me.SelectedPackagesAction.Size = New System.Drawing.Size(266, 26)
         Me.SelectedPackagesAction.Text = "&Action"
         '
         'SelectedPackagesActionDoNothingMenuItem
         '
         Me.SelectedPackagesActionDoNothingMenuItem.Name = "SelectedPackagesActionDoNothingMenuItem"
-        Me.SelectedPackagesActionDoNothingMenuItem.Size = New System.Drawing.Size(134, 22)
+        Me.SelectedPackagesActionDoNothingMenuItem.Size = New System.Drawing.Size(167, 26)
         Me.SelectedPackagesActionDoNothingMenuItem.Text = "&Do nothing"
         '
         'SelectedPackagesActionInstallMenuItem
         '
         Me.SelectedPackagesActionInstallMenuItem.Name = "SelectedPackagesActionInstallMenuItem"
-        Me.SelectedPackagesActionInstallMenuItem.Size = New System.Drawing.Size(134, 22)
+        Me.SelectedPackagesActionInstallMenuItem.Size = New System.Drawing.Size(167, 26)
         Me.SelectedPackagesActionInstallMenuItem.Text = "&Install"
         '
         'SelectedPackagesSearchForLastSelectedID
         '
         Me.SelectedPackagesSearchForLastSelectedID.Name = "SelectedPackagesSearchForLastSelectedID"
-        Me.SelectedPackagesSearchForLastSelectedID.Size = New System.Drawing.Size(210, 22)
+        Me.SelectedPackagesSearchForLastSelectedID.Size = New System.Drawing.Size(266, 26)
         Me.SelectedPackagesSearchForLastSelectedID.Text = "&Search for last-selected ID"
         '
         'zSeparatorSelectedPackagesMenu
         '
         Me.zSeparatorSelectedPackagesMenu.Name = "zSeparatorSelectedPackagesMenu"
-        Me.zSeparatorSelectedPackagesMenu.Size = New System.Drawing.Size(207, 6)
+        Me.zSeparatorSelectedPackagesMenu.Size = New System.Drawing.Size(263, 6)
         '
         'SelectedPackagesProperties
         '
         Me.SelectedPackagesProperties.Name = "SelectedPackagesProperties"
-        Me.SelectedPackagesProperties.Size = New System.Drawing.Size(210, 22)
+        Me.SelectedPackagesProperties.Size = New System.Drawing.Size(266, 26)
         Me.SelectedPackagesProperties.Text = "&Properties..."
         '
         'ToolsToolStripMenuItem
         '
         Me.ToolsToolStripMenuItem.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.VerifyManifestToolStripMenuItem, Me.FindManifestToolStripMenuItem})
         Me.ToolsToolStripMenuItem.Name = "ToolsToolStripMenuItem"
-        Me.ToolsToolStripMenuItem.Size = New System.Drawing.Size(46, 20)
+        Me.ToolsToolStripMenuItem.Size = New System.Drawing.Size(58, 24)
         Me.ToolsToolStripMenuItem.Text = "&Tools"
         '
         'VerifyManifestToolStripMenuItem
         '
         Me.VerifyManifestToolStripMenuItem.Name = "VerifyManifestToolStripMenuItem"
-        Me.VerifyManifestToolStripMenuItem.Size = New System.Drawing.Size(265, 22)
+        Me.VerifyManifestToolStripMenuItem.Size = New System.Drawing.Size(328, 26)
         Me.VerifyManifestToolStripMenuItem.Text = "&Verify manifest"
         '
         'FindManifestToolStripMenuItem
         '
         Me.FindManifestToolStripMenuItem.Name = "FindManifestToolStripMenuItem"
-        Me.FindManifestToolStripMenuItem.Size = New System.Drawing.Size(265, 22)
+        Me.FindManifestToolStripMenuItem.Size = New System.Drawing.Size(328, 26)
         Me.FindManifestToolStripMenuItem.Text = "Find manifest using version and ID..."
         '
         'HelpToolStripMenuItem
         '
         Me.HelpToolStripMenuItem.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.AboutToolStripMenuItem})
         Me.HelpToolStripMenuItem.Name = "HelpToolStripMenuItem"
-        Me.HelpToolStripMenuItem.Size = New System.Drawing.Size(44, 20)
+        Me.HelpToolStripMenuItem.Size = New System.Drawing.Size(55, 24)
         Me.HelpToolStripMenuItem.Text = "&Help"
         '
         'AboutToolStripMenuItem
         '
         Me.AboutToolStripMenuItem.Name = "AboutToolStripMenuItem"
-        Me.AboutToolStripMenuItem.Size = New System.Drawing.Size(107, 22)
+        Me.AboutToolStripMenuItem.Size = New System.Drawing.Size(133, 26)
         Me.AboutToolStripMenuItem.Text = "&About"
         '
         'contextmenustripPackageMenu
@@ -295,42 +295,42 @@ Partial Class aaformMainWindow
         Me.contextmenustripPackageMenu.ImageScalingSize = New System.Drawing.Size(20, 20)
         Me.contextmenustripPackageMenu.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.ActionToolStripMenuItem, Me.SearchForPackageIDFromContextMenu, Me.zSeparatorPackageContextMenu, Me.PropertiesPackageContextMenuToolStripMenuItem})
         Me.contextmenustripPackageMenu.Name = "ContextMenuStrip1"
-        Me.contextmenustripPackageMenu.Size = New System.Drawing.Size(211, 76)
+        Me.contextmenustripPackageMenu.Size = New System.Drawing.Size(253, 82)
         '
         'ActionToolStripMenuItem
         '
         Me.ActionToolStripMenuItem.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.DoNothingToolStripMenuItem, Me.InstallToolStripMenuItem})
         Me.ActionToolStripMenuItem.Name = "ActionToolStripMenuItem"
-        Me.ActionToolStripMenuItem.Size = New System.Drawing.Size(210, 22)
+        Me.ActionToolStripMenuItem.Size = New System.Drawing.Size(252, 24)
         Me.ActionToolStripMenuItem.Text = "&Action"
         '
         'DoNothingToolStripMenuItem
         '
         Me.DoNothingToolStripMenuItem.Name = "DoNothingToolStripMenuItem"
-        Me.DoNothingToolStripMenuItem.Size = New System.Drawing.Size(134, 22)
+        Me.DoNothingToolStripMenuItem.Size = New System.Drawing.Size(167, 26)
         Me.DoNothingToolStripMenuItem.Text = "&Do nothing"
         '
         'InstallToolStripMenuItem
         '
         Me.InstallToolStripMenuItem.Name = "InstallToolStripMenuItem"
-        Me.InstallToolStripMenuItem.Size = New System.Drawing.Size(134, 22)
+        Me.InstallToolStripMenuItem.Size = New System.Drawing.Size(167, 26)
         Me.InstallToolStripMenuItem.Text = "&Install"
         '
         'SearchForPackageIDFromContextMenu
         '
         Me.SearchForPackageIDFromContextMenu.Name = "SearchForPackageIDFromContextMenu"
-        Me.SearchForPackageIDFromContextMenu.Size = New System.Drawing.Size(210, 22)
+        Me.SearchForPackageIDFromContextMenu.Size = New System.Drawing.Size(252, 24)
         Me.SearchForPackageIDFromContextMenu.Text = "&Search for last-selected ID"
         '
         'zSeparatorPackageContextMenu
         '
         Me.zSeparatorPackageContextMenu.Name = "zSeparatorPackageContextMenu"
-        Me.zSeparatorPackageContextMenu.Size = New System.Drawing.Size(207, 6)
+        Me.zSeparatorPackageContextMenu.Size = New System.Drawing.Size(249, 6)
         '
         'PropertiesPackageContextMenuToolStripMenuItem
         '
         Me.PropertiesPackageContextMenuToolStripMenuItem.Name = "PropertiesPackageContextMenuToolStripMenuItem"
-        Me.PropertiesPackageContextMenuToolStripMenuItem.Size = New System.Drawing.Size(210, 22)
+        Me.PropertiesPackageContextMenuToolStripMenuItem.Size = New System.Drawing.Size(252, 24)
         Me.PropertiesPackageContextMenuToolStripMenuItem.Text = "&Properties..."
         '
         'splitcontainerMainWindow
@@ -348,9 +348,8 @@ Partial Class aaformMainWindow
         'splitcontainerMainWindow.Panel2
         '
         Me.splitcontainerMainWindow.Panel2.Controls.Add(Me.textboxPackageDetails)
-        Me.splitcontainerMainWindow.Size = New System.Drawing.Size(663, 507)
-        Me.splitcontainerMainWindow.SplitterDistance = 338
-        Me.splitcontainerMainWindow.SplitterWidth = 3
+        Me.splitcontainerMainWindow.Size = New System.Drawing.Size(829, 641)
+        Me.splitcontainerMainWindow.SplitterDistance = 427
         Me.splitcontainerMainWindow.TabIndex = 4
         '
         'panelPackageListHolder
@@ -361,7 +360,7 @@ Partial Class aaformMainWindow
         Me.panelPackageListHolder.Location = New System.Drawing.Point(0, 0)
         Me.panelPackageListHolder.Margin = New System.Windows.Forms.Padding(2)
         Me.panelPackageListHolder.Name = "panelPackageListHolder"
-        Me.panelPackageListHolder.Size = New System.Drawing.Size(663, 338)
+        Me.panelPackageListHolder.Size = New System.Drawing.Size(829, 427)
         Me.panelPackageListHolder.TabIndex = 2
         '
         'datagridviewPackageList
@@ -372,43 +371,43 @@ Partial Class aaformMainWindow
         Me.datagridviewPackageList.AllowUserToResizeRows = False
         Me.datagridviewPackageList.AutoSizeColumnsMode = System.Windows.Forms.DataGridViewAutoSizeColumnsMode.Fill
         Me.datagridviewPackageList.BackgroundColor = System.Drawing.SystemColors.Window
-        DataGridViewCellStyle4.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft
-        DataGridViewCellStyle4.BackColor = System.Drawing.SystemColors.Control
-        DataGridViewCellStyle4.Font = New System.Drawing.Font("Microsoft Sans Serif", 7.8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
-        DataGridViewCellStyle4.ForeColor = System.Drawing.SystemColors.WindowText
-        DataGridViewCellStyle4.SelectionBackColor = System.Drawing.SystemColors.Highlight
-        DataGridViewCellStyle4.SelectionForeColor = System.Drawing.SystemColors.HighlightText
-        DataGridViewCellStyle4.WrapMode = System.Windows.Forms.DataGridViewTriState.[True]
-        Me.datagridviewPackageList.ColumnHeadersDefaultCellStyle = DataGridViewCellStyle4
+        DataGridViewCellStyle1.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft
+        DataGridViewCellStyle1.BackColor = System.Drawing.SystemColors.Control
+        DataGridViewCellStyle1.Font = New System.Drawing.Font("Microsoft Sans Serif", 7.8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
+        DataGridViewCellStyle1.ForeColor = System.Drawing.SystemColors.WindowText
+        DataGridViewCellStyle1.SelectionBackColor = System.Drawing.SystemColors.Highlight
+        DataGridViewCellStyle1.SelectionForeColor = System.Drawing.SystemColors.HighlightText
+        DataGridViewCellStyle1.WrapMode = System.Windows.Forms.DataGridViewTriState.[True]
+        Me.datagridviewPackageList.ColumnHeadersDefaultCellStyle = DataGridViewCellStyle1
         Me.datagridviewPackageList.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize
-        Me.datagridviewPackageList.Columns.AddRange(New System.Windows.Forms.DataGridViewColumn() {Me.PkgAction, Me.PkgStatus, Me.PkgName, Me.FriendlyName, Me.AvailableVersion, Me.PkgDescription, Me.Manifest})
+        Me.datagridviewPackageList.Columns.AddRange(New System.Windows.Forms.DataGridViewColumn() {Me.PkgAction, Me.PkgStatus, Me.PkgName, Me.FriendlyName, Me.AvailableVersion, Me.LatestVersion, Me.PkgDescription, Me.Manifest})
         Me.datagridviewPackageList.ContextMenuStrip = Me.contextmenustripPackageMenu
-        DataGridViewCellStyle5.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft
-        DataGridViewCellStyle5.BackColor = System.Drawing.SystemColors.Window
-        DataGridViewCellStyle5.Font = New System.Drawing.Font("Microsoft Sans Serif", 7.8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
-        DataGridViewCellStyle5.ForeColor = System.Drawing.SystemColors.ControlText
-        DataGridViewCellStyle5.SelectionBackColor = System.Drawing.SystemColors.Highlight
-        DataGridViewCellStyle5.SelectionForeColor = System.Drawing.SystemColors.HighlightText
-        DataGridViewCellStyle5.WrapMode = System.Windows.Forms.DataGridViewTriState.[False]
-        Me.datagridviewPackageList.DefaultCellStyle = DataGridViewCellStyle5
+        DataGridViewCellStyle2.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft
+        DataGridViewCellStyle2.BackColor = System.Drawing.SystemColors.Window
+        DataGridViewCellStyle2.Font = New System.Drawing.Font("Microsoft Sans Serif", 7.8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
+        DataGridViewCellStyle2.ForeColor = System.Drawing.SystemColors.ControlText
+        DataGridViewCellStyle2.SelectionBackColor = System.Drawing.SystemColors.Highlight
+        DataGridViewCellStyle2.SelectionForeColor = System.Drawing.SystemColors.HighlightText
+        DataGridViewCellStyle2.WrapMode = System.Windows.Forms.DataGridViewTriState.[False]
+        Me.datagridviewPackageList.DefaultCellStyle = DataGridViewCellStyle2
         Me.datagridviewPackageList.Dock = System.Windows.Forms.DockStyle.Fill
         Me.datagridviewPackageList.Location = New System.Drawing.Point(0, 0)
         Me.datagridviewPackageList.Margin = New System.Windows.Forms.Padding(2)
         Me.datagridviewPackageList.Name = "datagridviewPackageList"
-        DataGridViewCellStyle6.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft
-        DataGridViewCellStyle6.BackColor = System.Drawing.SystemColors.Control
-        DataGridViewCellStyle6.Font = New System.Drawing.Font("Microsoft Sans Serif", 7.8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
-        DataGridViewCellStyle6.ForeColor = System.Drawing.SystemColors.WindowText
-        DataGridViewCellStyle6.SelectionBackColor = System.Drawing.SystemColors.Highlight
-        DataGridViewCellStyle6.SelectionForeColor = System.Drawing.SystemColors.HighlightText
-        DataGridViewCellStyle6.WrapMode = System.Windows.Forms.DataGridViewTriState.[True]
-        Me.datagridviewPackageList.RowHeadersDefaultCellStyle = DataGridViewCellStyle6
+        DataGridViewCellStyle3.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft
+        DataGridViewCellStyle3.BackColor = System.Drawing.SystemColors.Control
+        DataGridViewCellStyle3.Font = New System.Drawing.Font("Microsoft Sans Serif", 7.8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
+        DataGridViewCellStyle3.ForeColor = System.Drawing.SystemColors.WindowText
+        DataGridViewCellStyle3.SelectionBackColor = System.Drawing.SystemColors.Highlight
+        DataGridViewCellStyle3.SelectionForeColor = System.Drawing.SystemColors.HighlightText
+        DataGridViewCellStyle3.WrapMode = System.Windows.Forms.DataGridViewTriState.[True]
+        Me.datagridviewPackageList.RowHeadersDefaultCellStyle = DataGridViewCellStyle3
         Me.datagridviewPackageList.RowHeadersVisible = False
         Me.datagridviewPackageList.RowHeadersWidth = 51
         Me.datagridviewPackageList.RowTemplate.Height = 24
         Me.datagridviewPackageList.SelectionMode = System.Windows.Forms.DataGridViewSelectionMode.FullRowSelect
         Me.datagridviewPackageList.ShowEditingIcon = False
-        Me.datagridviewPackageList.Size = New System.Drawing.Size(663, 338)
+        Me.datagridviewPackageList.Size = New System.Drawing.Size(829, 427)
         Me.datagridviewPackageList.StandardTab = True
         Me.datagridviewPackageList.TabIndex = 0
         '
@@ -420,7 +419,7 @@ Partial Class aaformMainWindow
         Me.PkgAction.MinimumWidth = 6
         Me.PkgAction.Name = "PkgAction"
         Me.PkgAction.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Automatic
-        Me.PkgAction.Width = 62
+        Me.PkgAction.Width = 76
         '
         'PkgStatus
         '
@@ -428,45 +427,45 @@ Partial Class aaformMainWindow
         Me.PkgStatus.HeaderText = "Status"
         Me.PkgStatus.MinimumWidth = 6
         Me.PkgStatus.Name = "PkgStatus"
-        Me.PkgStatus.ReadOnly = True
-        Me.PkgStatus.Width = 62
+        Me.PkgStatus.Width = 77
         '
         'PkgName
         '
         Me.PkgName.HeaderText = "Package"
         Me.PkgName.MinimumWidth = 6
         Me.PkgName.Name = "PkgName"
-        Me.PkgName.ReadOnly = True
         '
         'FriendlyName
         '
         Me.FriendlyName.HeaderText = "Name"
         Me.FriendlyName.MinimumWidth = 6
         Me.FriendlyName.Name = "FriendlyName"
-        Me.FriendlyName.ReadOnly = True
         '
         'AvailableVersion
         '
         Me.AvailableVersion.HeaderText = "Version"
         Me.AvailableVersion.MinimumWidth = 6
         Me.AvailableVersion.Name = "AvailableVersion"
-        Me.AvailableVersion.ReadOnly = True
         Me.AvailableVersion.ToolTipText = "(will eventually only display latest version and have all older versions in a win" &
     "dow like Synaptic)"
+        '
+        'LatestVersion
+        '
+        Me.LatestVersion.HeaderText = "Latest version"
+        Me.LatestVersion.MinimumWidth = 6
+        Me.LatestVersion.Name = "LatestVersion"
         '
         'PkgDescription
         '
         Me.PkgDescription.HeaderText = "Description"
         Me.PkgDescription.MinimumWidth = 6
         Me.PkgDescription.Name = "PkgDescription"
-        Me.PkgDescription.ReadOnly = True
         '
         'Manifest
         '
         Me.Manifest.HeaderText = "Manifest"
         Me.Manifest.MinimumWidth = 6
         Me.Manifest.Name = "Manifest"
-        Me.Manifest.ReadOnly = True
         Me.Manifest.Visible = False
         '
         'labelUpdatingPackageList
@@ -478,7 +477,7 @@ Partial Class aaformMainWindow
         Me.labelUpdatingPackageList.Location = New System.Drawing.Point(2, 0)
         Me.labelUpdatingPackageList.Margin = New System.Windows.Forms.Padding(2, 0, 2, 0)
         Me.labelUpdatingPackageList.Name = "labelUpdatingPackageList"
-        Me.labelUpdatingPackageList.Size = New System.Drawing.Size(173, 13)
+        Me.labelUpdatingPackageList.Size = New System.Drawing.Size(228, 17)
         Me.labelUpdatingPackageList.TabIndex = 1
         Me.labelUpdatingPackageList.Text = "Loading package list, please wait..."
         '
@@ -491,7 +490,7 @@ Partial Class aaformMainWindow
         Me.textboxPackageDetails.Name = "textboxPackageDetails"
         Me.textboxPackageDetails.ReadOnly = True
         Me.textboxPackageDetails.ScrollBars = System.Windows.Forms.ScrollBars.Vertical
-        Me.textboxPackageDetails.Size = New System.Drawing.Size(663, 166)
+        Me.textboxPackageDetails.Size = New System.Drawing.Size(829, 210)
         Me.textboxPackageDetails.TabIndex = 1
         Me.textboxPackageDetails.Text = resources.GetString("textboxPackageDetails.Text")
         '
@@ -502,16 +501,16 @@ Partial Class aaformMainWindow
         Me.panelMainPkgArea.Location = New System.Drawing.Point(0, 0)
         Me.panelMainPkgArea.Margin = New System.Windows.Forms.Padding(2)
         Me.panelMainPkgArea.Name = "panelMainPkgArea"
-        Me.panelMainPkgArea.Size = New System.Drawing.Size(663, 507)
+        Me.panelMainPkgArea.Size = New System.Drawing.Size(829, 641)
         Me.panelMainPkgArea.TabIndex = 2
         '
         'toolstripMainWindow
         '
         Me.toolstripMainWindow.ImageScalingSize = New System.Drawing.Size(20, 20)
         Me.toolstripMainWindow.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.toolstripbuttonRefreshCache, Me.toolstripbuttonApplyChanges, Me.zSeparatorApplyChangesAndProperties, Me.toolstripbuttonProperties, Me.zSeparatorPropertiesAndSearchBox, Me.toolstriptextboxSearch, Me.toolstripsplitbuttonSearch})
-        Me.toolstripMainWindow.Location = New System.Drawing.Point(0, 24)
+        Me.toolstripMainWindow.Location = New System.Drawing.Point(0, 28)
         Me.toolstripMainWindow.Name = "toolstripMainWindow"
-        Me.toolstripMainWindow.Size = New System.Drawing.Size(884, 25)
+        Me.toolstripMainWindow.Size = New System.Drawing.Size(1105, 27)
         Me.toolstripMainWindow.TabIndex = 6
         Me.toolstripMainWindow.TabStop = True
         Me.toolstripMainWindow.Text = "ToolStrip1"
@@ -522,7 +521,7 @@ Partial Class aaformMainWindow
         Me.toolstripbuttonRefreshCache.Image = CType(resources.GetObject("toolstripbuttonRefreshCache.Image"), System.Drawing.Image)
         Me.toolstripbuttonRefreshCache.ImageTransparentColor = System.Drawing.Color.Magenta
         Me.toolstripbuttonRefreshCache.Name = "toolstripbuttonRefreshCache"
-        Me.toolstripbuttonRefreshCache.Size = New System.Drawing.Size(84, 22)
+        Me.toolstripbuttonRefreshCache.Size = New System.Drawing.Size(104, 24)
         Me.toolstripbuttonRefreshCache.Text = "Refresh cache"
         Me.toolstripbuttonRefreshCache.TextImageRelation = System.Windows.Forms.TextImageRelation.ImageAboveText
         '
@@ -532,14 +531,14 @@ Partial Class aaformMainWindow
         Me.toolstripbuttonApplyChanges.Image = CType(resources.GetObject("toolstripbuttonApplyChanges.Image"), System.Drawing.Image)
         Me.toolstripbuttonApplyChanges.ImageTransparentColor = System.Drawing.Color.Magenta
         Me.toolstripbuttonApplyChanges.Name = "toolstripbuttonApplyChanges"
-        Me.toolstripbuttonApplyChanges.Size = New System.Drawing.Size(98, 22)
+        Me.toolstripbuttonApplyChanges.Size = New System.Drawing.Size(119, 24)
         Me.toolstripbuttonApplyChanges.Text = "Apply changes..."
         Me.toolstripbuttonApplyChanges.TextImageRelation = System.Windows.Forms.TextImageRelation.ImageAboveText
         '
         'zSeparatorApplyChangesAndProperties
         '
         Me.zSeparatorApplyChangesAndProperties.Name = "zSeparatorApplyChangesAndProperties"
-        Me.zSeparatorApplyChangesAndProperties.Size = New System.Drawing.Size(6, 25)
+        Me.zSeparatorApplyChangesAndProperties.Size = New System.Drawing.Size(6, 27)
         '
         'toolstripbuttonProperties
         '
@@ -547,21 +546,21 @@ Partial Class aaformMainWindow
         Me.toolstripbuttonProperties.Image = CType(resources.GetObject("toolstripbuttonProperties.Image"), System.Drawing.Image)
         Me.toolstripbuttonProperties.ImageTransparentColor = System.Drawing.Color.Magenta
         Me.toolstripbuttonProperties.Name = "toolstripbuttonProperties"
-        Me.toolstripbuttonProperties.Size = New System.Drawing.Size(73, 22)
+        Me.toolstripbuttonProperties.Size = New System.Drawing.Size(89, 24)
         Me.toolstripbuttonProperties.Text = "Properties..."
         Me.toolstripbuttonProperties.TextImageRelation = System.Windows.Forms.TextImageRelation.ImageAboveText
         '
         'zSeparatorPropertiesAndSearchBox
         '
         Me.zSeparatorPropertiesAndSearchBox.Name = "zSeparatorPropertiesAndSearchBox"
-        Me.zSeparatorPropertiesAndSearchBox.Size = New System.Drawing.Size(6, 25)
+        Me.zSeparatorPropertiesAndSearchBox.Size = New System.Drawing.Size(6, 27)
         '
         'toolstriptextboxSearch
         '
         Me.toolstriptextboxSearch.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle
         Me.toolstriptextboxSearch.Font = New System.Drawing.Font("Segoe UI", 9.0!)
         Me.toolstriptextboxSearch.Name = "toolstriptextboxSearch"
-        Me.toolstriptextboxSearch.Size = New System.Drawing.Size(200, 25)
+        Me.toolstriptextboxSearch.Size = New System.Drawing.Size(250, 27)
         '
         'toolstripsplitbuttonSearch
         '
@@ -570,13 +569,13 @@ Partial Class aaformMainWindow
         Me.toolstripsplitbuttonSearch.Image = CType(resources.GetObject("toolstripsplitbuttonSearch.Image"), System.Drawing.Image)
         Me.toolstripsplitbuttonSearch.ImageTransparentColor = System.Drawing.Color.Magenta
         Me.toolstripsplitbuttonSearch.Name = "toolstripsplitbuttonSearch"
-        Me.toolstripsplitbuttonSearch.Size = New System.Drawing.Size(58, 22)
+        Me.toolstripsplitbuttonSearch.Size = New System.Drawing.Size(72, 24)
         Me.toolstripsplitbuttonSearch.Text = "Search"
         '
         'toolstripmenuitemAdvancedSearch
         '
         Me.toolstripmenuitemAdvancedSearch.Name = "toolstripmenuitemAdvancedSearch"
-        Me.toolstripmenuitemAdvancedSearch.Size = New System.Drawing.Size(161, 22)
+        Me.toolstripmenuitemAdvancedSearch.Size = New System.Drawing.Size(199, 26)
         Me.toolstripmenuitemAdvancedSearch.Text = "Search &options..."
         '
         'splitcontainerSidebarAndPkgList
@@ -593,9 +592,8 @@ Partial Class aaformMainWindow
         'splitcontainerSidebarAndPkgList.Panel2
         '
         Me.splitcontainerSidebarAndPkgList.Panel2.Controls.Add(Me.panelMainPkgArea)
-        Me.splitcontainerSidebarAndPkgList.Size = New System.Drawing.Size(884, 507)
-        Me.splitcontainerSidebarAndPkgList.SplitterDistance = 218
-        Me.splitcontainerSidebarAndPkgList.SplitterWidth = 3
+        Me.splitcontainerSidebarAndPkgList.Size = New System.Drawing.Size(1105, 641)
+        Me.splitcontainerSidebarAndPkgList.SplitterDistance = 272
         Me.splitcontainerSidebarAndPkgList.TabIndex = 5
         '
         'panelSidebarHolder
@@ -607,7 +605,7 @@ Partial Class aaformMainWindow
         Me.panelSidebarHolder.Location = New System.Drawing.Point(0, 0)
         Me.panelSidebarHolder.Margin = New System.Windows.Forms.Padding(2)
         Me.panelSidebarHolder.Name = "panelSidebarHolder"
-        Me.panelSidebarHolder.Size = New System.Drawing.Size(218, 507)
+        Me.panelSidebarHolder.Size = New System.Drawing.Size(272, 641)
         Me.panelSidebarHolder.TabIndex = 0
         '
         'buttonCloseSidebar
@@ -615,9 +613,10 @@ Partial Class aaformMainWindow
         Me.buttonCloseSidebar.Anchor = CType((System.Windows.Forms.AnchorStyles.Top Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)
         Me.buttonCloseSidebar.AutoSize = True
         Me.buttonCloseSidebar.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
-        Me.buttonCloseSidebar.Location = New System.Drawing.Point(187, 3)
+        Me.buttonCloseSidebar.Location = New System.Drawing.Point(237, 4)
+        Me.buttonCloseSidebar.Margin = New System.Windows.Forms.Padding(4)
         Me.buttonCloseSidebar.Name = "buttonCloseSidebar"
-        Me.buttonCloseSidebar.Size = New System.Drawing.Size(24, 23)
+        Me.buttonCloseSidebar.Size = New System.Drawing.Size(27, 27)
         Me.buttonCloseSidebar.TabIndex = 4
         Me.buttonCloseSidebar.Text = "X"
         Me.buttonCloseSidebar.UseVisualStyleBackColor = True
@@ -629,9 +628,10 @@ Partial Class aaformMainWindow
         Me.comboboxSidebarTabSelector.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList
         Me.comboboxSidebarTabSelector.FormattingEnabled = True
         Me.comboboxSidebarTabSelector.Items.AddRange(New Object() {"Search terms"})
-        Me.comboboxSidebarTabSelector.Location = New System.Drawing.Point(8, 3)
+        Me.comboboxSidebarTabSelector.Location = New System.Drawing.Point(10, 4)
+        Me.comboboxSidebarTabSelector.Margin = New System.Windows.Forms.Padding(4)
         Me.comboboxSidebarTabSelector.Name = "comboboxSidebarTabSelector"
-        Me.comboboxSidebarTabSelector.Size = New System.Drawing.Size(172, 21)
+        Me.comboboxSidebarTabSelector.Size = New System.Drawing.Size(214, 24)
         Me.comboboxSidebarTabSelector.TabIndex = 3
         '
         'tabcontrolSidebar
@@ -647,11 +647,11 @@ Partial Class aaformMainWindow
         Me.tabcontrolSidebar.Controls.Add(Me.tabpageSource)
         Me.tabcontrolSidebar.Controls.Add(Me.tabpageArchitecture)
         Me.tabcontrolSidebar.ItemSize = New System.Drawing.Size(0, 1)
-        Me.tabcontrolSidebar.Location = New System.Drawing.Point(4, 26)
+        Me.tabcontrolSidebar.Location = New System.Drawing.Point(5, 32)
         Me.tabcontrolSidebar.Margin = New System.Windows.Forms.Padding(2)
         Me.tabcontrolSidebar.Name = "tabcontrolSidebar"
         Me.tabcontrolSidebar.SelectedIndex = 0
-        Me.tabcontrolSidebar.Size = New System.Drawing.Size(211, 479)
+        Me.tabcontrolSidebar.Size = New System.Drawing.Size(264, 606)
         Me.tabcontrolSidebar.SizeMode = System.Windows.Forms.TabSizeMode.Fixed
         Me.tabcontrolSidebar.TabIndex = 2
         '
@@ -661,7 +661,7 @@ Partial Class aaformMainWindow
         Me.tabpageSearchTerms.Location = New System.Drawing.Point(4, 5)
         Me.tabpageSearchTerms.Margin = New System.Windows.Forms.Padding(2)
         Me.tabpageSearchTerms.Name = "tabpageSearchTerms"
-        Me.tabpageSearchTerms.Size = New System.Drawing.Size(203, 470)
+        Me.tabpageSearchTerms.Size = New System.Drawing.Size(256, 597)
         Me.tabpageSearchTerms.TabIndex = 4
         Me.tabpageSearchTerms.Text = "Search terms"
         Me.tabpageSearchTerms.UseVisualStyleBackColor = True
@@ -672,11 +672,12 @@ Partial Class aaformMainWindow
         Me.listboxSearchTerms.Dock = System.Windows.Forms.DockStyle.Fill
         Me.listboxSearchTerms.FormattingEnabled = True
         Me.listboxSearchTerms.IntegralHeight = False
+        Me.listboxSearchTerms.ItemHeight = 16
         Me.listboxSearchTerms.Items.AddRange(New Object() {"All"})
         Me.listboxSearchTerms.Location = New System.Drawing.Point(0, 0)
         Me.listboxSearchTerms.Margin = New System.Windows.Forms.Padding(2)
         Me.listboxSearchTerms.Name = "listboxSearchTerms"
-        Me.listboxSearchTerms.Size = New System.Drawing.Size(203, 470)
+        Me.listboxSearchTerms.Size = New System.Drawing.Size(256, 597)
         Me.listboxSearchTerms.TabIndex = 2
         '
         'contextmenuSearchTerm
@@ -684,23 +685,23 @@ Partial Class aaformMainWindow
         Me.contextmenuSearchTerm.ImageScalingSize = New System.Drawing.Size(20, 20)
         Me.contextmenuSearchTerm.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.ClearSelectedSearchTermToolStripMenuItem, Me.zSeparatorSearchSidebarContextMenu, Me.ClearAllSearchTermsToolStripMenuItem})
         Me.contextmenuSearchTerm.Name = "contextmenuSearchTerm"
-        Me.contextmenuSearchTerm.Size = New System.Drawing.Size(213, 54)
+        Me.contextmenuSearchTerm.Size = New System.Drawing.Size(253, 58)
         '
         'ClearSelectedSearchTermToolStripMenuItem
         '
         Me.ClearSelectedSearchTermToolStripMenuItem.Name = "ClearSelectedSearchTermToolStripMenuItem"
-        Me.ClearSelectedSearchTermToolStripMenuItem.Size = New System.Drawing.Size(212, 22)
+        Me.ClearSelectedSearchTermToolStripMenuItem.Size = New System.Drawing.Size(252, 24)
         Me.ClearSelectedSearchTermToolStripMenuItem.Text = "Clear selected search term"
         '
         'zSeparatorSearchSidebarContextMenu
         '
         Me.zSeparatorSearchSidebarContextMenu.Name = "zSeparatorSearchSidebarContextMenu"
-        Me.zSeparatorSearchSidebarContextMenu.Size = New System.Drawing.Size(209, 6)
+        Me.zSeparatorSearchSidebarContextMenu.Size = New System.Drawing.Size(249, 6)
         '
         'ClearAllSearchTermsToolStripMenuItem
         '
         Me.ClearAllSearchTermsToolStripMenuItem.Name = "ClearAllSearchTermsToolStripMenuItem"
-        Me.ClearAllSearchTermsToolStripMenuItem.Size = New System.Drawing.Size(212, 22)
+        Me.ClearAllSearchTermsToolStripMenuItem.Size = New System.Drawing.Size(252, 24)
         Me.ClearAllSearchTermsToolStripMenuItem.Text = "Clear all search terms"
         '
         'tabpageStatus
@@ -710,7 +711,7 @@ Partial Class aaformMainWindow
         Me.tabpageStatus.Margin = New System.Windows.Forms.Padding(2)
         Me.tabpageStatus.Name = "tabpageStatus"
         Me.tabpageStatus.Padding = New System.Windows.Forms.Padding(2)
-        Me.tabpageStatus.Size = New System.Drawing.Size(203, 470)
+        Me.tabpageStatus.Size = New System.Drawing.Size(256, 597)
         Me.tabpageStatus.TabIndex = 1
         Me.tabpageStatus.Text = "Status"
         Me.tabpageStatus.UseVisualStyleBackColor = True
@@ -720,11 +721,12 @@ Partial Class aaformMainWindow
         Me.listboxStatusTab.Dock = System.Windows.Forms.DockStyle.Fill
         Me.listboxStatusTab.FormattingEnabled = True
         Me.listboxStatusTab.IntegralHeight = False
+        Me.listboxStatusTab.ItemHeight = 16
         Me.listboxStatusTab.Items.AddRange(New Object() {"All"})
         Me.listboxStatusTab.Location = New System.Drawing.Point(2, 2)
         Me.listboxStatusTab.Margin = New System.Windows.Forms.Padding(2)
         Me.listboxStatusTab.Name = "listboxStatusTab"
-        Me.listboxStatusTab.Size = New System.Drawing.Size(199, 466)
+        Me.listboxStatusTab.Size = New System.Drawing.Size(252, 593)
         Me.listboxStatusTab.TabIndex = 0
         '
         'tabpageCustomFilters
@@ -733,7 +735,7 @@ Partial Class aaformMainWindow
         Me.tabpageCustomFilters.Location = New System.Drawing.Point(4, 5)
         Me.tabpageCustomFilters.Margin = New System.Windows.Forms.Padding(2)
         Me.tabpageCustomFilters.Name = "tabpageCustomFilters"
-        Me.tabpageCustomFilters.Size = New System.Drawing.Size(203, 470)
+        Me.tabpageCustomFilters.Size = New System.Drawing.Size(256, 597)
         Me.tabpageCustomFilters.TabIndex = 3
         Me.tabpageCustomFilters.Text = "Custom filters"
         Me.tabpageCustomFilters.UseVisualStyleBackColor = True
@@ -743,11 +745,12 @@ Partial Class aaformMainWindow
         Me.listboxCustomFilters.Dock = System.Windows.Forms.DockStyle.Fill
         Me.listboxCustomFilters.FormattingEnabled = True
         Me.listboxCustomFilters.IntegralHeight = False
+        Me.listboxCustomFilters.ItemHeight = 16
         Me.listboxCustomFilters.Items.AddRange(New Object() {"All"})
         Me.listboxCustomFilters.Location = New System.Drawing.Point(0, 0)
         Me.listboxCustomFilters.Margin = New System.Windows.Forms.Padding(2)
         Me.listboxCustomFilters.Name = "listboxCustomFilters"
-        Me.listboxCustomFilters.Size = New System.Drawing.Size(203, 470)
+        Me.listboxCustomFilters.Size = New System.Drawing.Size(256, 597)
         Me.listboxCustomFilters.TabIndex = 1
         '
         'tabpageSections
@@ -757,7 +760,7 @@ Partial Class aaformMainWindow
         Me.tabpageSections.Margin = New System.Windows.Forms.Padding(2)
         Me.tabpageSections.Name = "tabpageSections"
         Me.tabpageSections.Padding = New System.Windows.Forms.Padding(2)
-        Me.tabpageSections.Size = New System.Drawing.Size(203, 470)
+        Me.tabpageSections.Size = New System.Drawing.Size(256, 597)
         Me.tabpageSections.TabIndex = 0
         Me.tabpageSections.Text = "Categories"
         Me.tabpageSections.UseVisualStyleBackColor = True
@@ -767,11 +770,12 @@ Partial Class aaformMainWindow
         Me.listboxSections.Dock = System.Windows.Forms.DockStyle.Fill
         Me.listboxSections.FormattingEnabled = True
         Me.listboxSections.IntegralHeight = False
+        Me.listboxSections.ItemHeight = 16
         Me.listboxSections.Items.AddRange(New Object() {"All"})
         Me.listboxSections.Location = New System.Drawing.Point(2, 2)
         Me.listboxSections.Margin = New System.Windows.Forms.Padding(2)
         Me.listboxSections.Name = "listboxSections"
-        Me.listboxSections.Size = New System.Drawing.Size(199, 466)
+        Me.listboxSections.Size = New System.Drawing.Size(252, 593)
         Me.listboxSections.TabIndex = 1
         '
         'tabpageSource
@@ -780,7 +784,7 @@ Partial Class aaformMainWindow
         Me.tabpageSource.Location = New System.Drawing.Point(4, 5)
         Me.tabpageSource.Margin = New System.Windows.Forms.Padding(2)
         Me.tabpageSource.Name = "tabpageSource"
-        Me.tabpageSource.Size = New System.Drawing.Size(203, 470)
+        Me.tabpageSource.Size = New System.Drawing.Size(256, 597)
         Me.tabpageSource.TabIndex = 2
         Me.tabpageSource.Text = "Source"
         Me.tabpageSource.UseVisualStyleBackColor = True
@@ -790,11 +794,12 @@ Partial Class aaformMainWindow
         Me.listboxSourceTab.Dock = System.Windows.Forms.DockStyle.Fill
         Me.listboxSourceTab.FormattingEnabled = True
         Me.listboxSourceTab.IntegralHeight = False
+        Me.listboxSourceTab.ItemHeight = 16
         Me.listboxSourceTab.Items.AddRange(New Object() {"All"})
         Me.listboxSourceTab.Location = New System.Drawing.Point(0, 0)
         Me.listboxSourceTab.Margin = New System.Windows.Forms.Padding(2)
         Me.listboxSourceTab.Name = "listboxSourceTab"
-        Me.listboxSourceTab.Size = New System.Drawing.Size(203, 470)
+        Me.listboxSourceTab.Size = New System.Drawing.Size(256, 597)
         Me.listboxSourceTab.TabIndex = 1
         '
         'tabpageArchitecture
@@ -803,7 +808,7 @@ Partial Class aaformMainWindow
         Me.tabpageArchitecture.Location = New System.Drawing.Point(4, 5)
         Me.tabpageArchitecture.Margin = New System.Windows.Forms.Padding(2)
         Me.tabpageArchitecture.Name = "tabpageArchitecture"
-        Me.tabpageArchitecture.Size = New System.Drawing.Size(203, 470)
+        Me.tabpageArchitecture.Size = New System.Drawing.Size(256, 597)
         Me.tabpageArchitecture.TabIndex = 5
         Me.tabpageArchitecture.Text = "Architecture"
         Me.tabpageArchitecture.UseVisualStyleBackColor = True
@@ -813,57 +818,57 @@ Partial Class aaformMainWindow
         Me.listboxArchitecture.Dock = System.Windows.Forms.DockStyle.Fill
         Me.listboxArchitecture.FormattingEnabled = True
         Me.listboxArchitecture.IntegralHeight = False
+        Me.listboxArchitecture.ItemHeight = 16
         Me.listboxArchitecture.Items.AddRange(New Object() {"All"})
         Me.listboxArchitecture.Location = New System.Drawing.Point(0, 0)
         Me.listboxArchitecture.Margin = New System.Windows.Forms.Padding(2)
         Me.listboxArchitecture.Name = "listboxArchitecture"
-        Me.listboxArchitecture.Size = New System.Drawing.Size(203, 470)
+        Me.listboxArchitecture.Size = New System.Drawing.Size(256, 597)
         Me.listboxArchitecture.TabIndex = 1
         '
         'panelMainForm
         '
         Me.panelMainForm.Controls.Add(Me.splitcontainerSidebarAndPkgList)
         Me.panelMainForm.Dock = System.Windows.Forms.DockStyle.Fill
-        Me.panelMainForm.Location = New System.Drawing.Point(0, 49)
+        Me.panelMainForm.Location = New System.Drawing.Point(0, 55)
         Me.panelMainForm.Margin = New System.Windows.Forms.Padding(2)
         Me.panelMainForm.Name = "panelMainForm"
-        Me.panelMainForm.Size = New System.Drawing.Size(884, 507)
+        Me.panelMainForm.Size = New System.Drawing.Size(1105, 641)
         Me.panelMainForm.TabIndex = 4
         '
         'statusbarMainWindow
         '
         Me.statusbarMainWindow.ImageScalingSize = New System.Drawing.Size(20, 20)
         Me.statusbarMainWindow.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.toolstripstatuslabelPackageCount, Me.toolstripstatusSplitter, Me.toolstripprogressbarLoadingPackages, Me.toolstripstatuslabelLoadingPackageCount})
-        Me.statusbarMainWindow.Location = New System.Drawing.Point(0, 556)
+        Me.statusbarMainWindow.Location = New System.Drawing.Point(0, 696)
         Me.statusbarMainWindow.Name = "statusbarMainWindow"
-        Me.statusbarMainWindow.Padding = New System.Windows.Forms.Padding(1, 0, 11, 0)
-        Me.statusbarMainWindow.Size = New System.Drawing.Size(884, 22)
+        Me.statusbarMainWindow.Size = New System.Drawing.Size(1105, 26)
         Me.statusbarMainWindow.TabIndex = 5
         Me.statusbarMainWindow.Text = "StatusStrip1"
         '
         'toolstripstatuslabelPackageCount
         '
         Me.toolstripstatuslabelPackageCount.Name = "toolstripstatuslabelPackageCount"
-        Me.toolstripstatuslabelPackageCount.Size = New System.Drawing.Size(107, 17)
+        Me.toolstripstatuslabelPackageCount.Size = New System.Drawing.Size(137, 20)
         Me.toolstripstatuslabelPackageCount.Text = "0 packages loaded."
         '
         'toolstripstatusSplitter
         '
         Me.toolstripstatusSplitter.Name = "toolstripstatusSplitter"
-        Me.toolstripstatusSplitter.Size = New System.Drawing.Size(10, 17)
+        Me.toolstripstatusSplitter.Size = New System.Drawing.Size(13, 20)
         Me.toolstripstatusSplitter.Text = "|"
         Me.toolstripstatusSplitter.Visible = False
         '
         'toolstripprogressbarLoadingPackages
         '
         Me.toolstripprogressbarLoadingPackages.Name = "toolstripprogressbarLoadingPackages"
-        Me.toolstripprogressbarLoadingPackages.Size = New System.Drawing.Size(120, 16)
+        Me.toolstripprogressbarLoadingPackages.Size = New System.Drawing.Size(150, 18)
         Me.toolstripprogressbarLoadingPackages.Visible = False
         '
         'toolstripstatuslabelLoadingPackageCount
         '
         Me.toolstripstatuslabelLoadingPackageCount.Name = "toolstripstatuslabelLoadingPackageCount"
-        Me.toolstripstatuslabelLoadingPackageCount.Size = New System.Drawing.Size(111, 17)
+        Me.toolstripstatuslabelLoadingPackageCount.Size = New System.Drawing.Size(138, 20)
         Me.toolstripstatuslabelLoadingPackageCount.Text = "Loading packages..."
         Me.toolstripstatuslabelLoadingPackageCount.Visible = False
         '
@@ -886,9 +891,9 @@ Partial Class aaformMainWindow
         '
         'aaformMainWindow
         '
-        Me.AutoScaleDimensions = New System.Drawing.SizeF(96.0!, 96.0!)
+        Me.AutoScaleDimensions = New System.Drawing.SizeF(120.0!, 120.0!)
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi
-        Me.ClientSize = New System.Drawing.Size(884, 578)
+        Me.ClientSize = New System.Drawing.Size(1105, 722)
         Me.Controls.Add(Me.panelMainForm)
         Me.Controls.Add(Me.statusbarMainWindow)
         Me.Controls.Add(Me.toolstripMainWindow)
@@ -989,13 +994,6 @@ Partial Class aaformMainWindow
     Friend WithEvents ApplyChangesMenuItem As ToolStripMenuItem
     Friend WithEvents zSeparatorPackageListMenu As ToolStripSeparator
     Friend WithEvents AdvancedSearchMenuItem As ToolStripMenuItem
-    Friend WithEvents PkgAction As DataGridViewComboBoxColumn
-    Friend WithEvents PkgStatus As DataGridViewTextBoxColumn
-    Friend WithEvents PkgName As DataGridViewTextBoxColumn
-    Friend WithEvents FriendlyName As DataGridViewTextBoxColumn
-    Friend WithEvents AvailableVersion As DataGridViewTextBoxColumn
-    Friend WithEvents PkgDescription As DataGridViewTextBoxColumn
-    Friend WithEvents Manifest As DataGridViewTextBoxColumn
     Friend WithEvents SearchMenuItem As ToolStripMenuItem
     Friend WithEvents comboboxSidebarTabSelector As ComboBox
     Friend WithEvents buttonCloseSidebar As Button
@@ -1015,4 +1013,12 @@ Partial Class aaformMainWindow
     Friend WithEvents zSeparatorSelectedPackagesMenu As ToolStripSeparator
     Friend WithEvents SelectedPackagesSearchForLastSelectedID As ToolStripMenuItem
     Friend WithEvents SelectedPackagesProperties As ToolStripMenuItem
+    Friend WithEvents PkgAction As DataGridViewComboBoxColumn
+    Friend WithEvents PkgStatus As DataGridViewTextBoxColumn
+    Friend WithEvents PkgName As DataGridViewTextBoxColumn
+    Friend WithEvents FriendlyName As DataGridViewTextBoxColumn
+    Friend WithEvents AvailableVersion As DataGridViewTextBoxColumn
+    Friend WithEvents LatestVersion As DataGridViewTextBoxColumn
+    Friend WithEvents PkgDescription As DataGridViewTextBoxColumn
+    Friend WithEvents Manifest As DataGridViewTextBoxColumn
 End Class

--- a/guinget/MainWindow.Designer.vb
+++ b/guinget/MainWindow.Designer.vb
@@ -394,6 +394,7 @@ Partial Class aaformMainWindow
         Me.datagridviewPackageList.Location = New System.Drawing.Point(0, 0)
         Me.datagridviewPackageList.Margin = New System.Windows.Forms.Padding(2)
         Me.datagridviewPackageList.Name = "datagridviewPackageList"
+        Me.datagridviewPackageList.ReadOnly = True
         DataGridViewCellStyle3.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft
         DataGridViewCellStyle3.BackColor = System.Drawing.SystemColors.Control
         DataGridViewCellStyle3.Font = New System.Drawing.Font("Microsoft Sans Serif", 7.8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
@@ -839,6 +840,7 @@ Partial Class aaformMainWindow
         Me.PkgAction.Items.AddRange(New Object() {"Do nothing", "Install"})
         Me.PkgAction.MinimumWidth = 6
         Me.PkgAction.Name = "PkgAction"
+        Me.PkgAction.ReadOnly = True
         Me.PkgAction.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Automatic
         Me.PkgAction.Width = 76
         '
@@ -880,6 +882,7 @@ Partial Class aaformMainWindow
         Me.LatestVersion.MinimumWidth = 6
         Me.LatestVersion.Name = "LatestVersion"
         Me.LatestVersion.ReadOnly = True
+        Me.LatestVersion.Visible = False
         '
         'PkgDescription
         '

--- a/guinget/MainWindow.Designer.vb
+++ b/guinget/MainWindow.Designer.vb
@@ -60,14 +60,6 @@ Partial Class aaformMainWindow
         Me.splitcontainerMainWindow = New System.Windows.Forms.SplitContainer()
         Me.panelPackageListHolder = New System.Windows.Forms.Panel()
         Me.datagridviewPackageList = New System.Windows.Forms.DataGridView()
-        Me.PkgAction = New System.Windows.Forms.DataGridViewComboBoxColumn()
-        Me.PkgStatus = New System.Windows.Forms.DataGridViewTextBoxColumn()
-        Me.PkgName = New System.Windows.Forms.DataGridViewTextBoxColumn()
-        Me.FriendlyName = New System.Windows.Forms.DataGridViewTextBoxColumn()
-        Me.AvailableVersion = New System.Windows.Forms.DataGridViewTextBoxColumn()
-        Me.LatestVersion = New System.Windows.Forms.DataGridViewTextBoxColumn()
-        Me.PkgDescription = New System.Windows.Forms.DataGridViewTextBoxColumn()
-        Me.Manifest = New System.Windows.Forms.DataGridViewTextBoxColumn()
         Me.labelUpdatingPackageList = New System.Windows.Forms.Label()
         Me.textboxPackageDetails = New System.Windows.Forms.TextBox()
         Me.panelMainPkgArea = New System.Windows.Forms.Panel()
@@ -110,6 +102,14 @@ Partial Class aaformMainWindow
         Me.SelectedPackageToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
         Me.zCantFindThisPackagePropertiesMenuItem = New System.Windows.Forms.ToolStripMenuItem()
         Me.zSeparatorNoIdeaWhereThisIs = New System.Windows.Forms.ToolStripSeparator()
+        Me.PkgAction = New System.Windows.Forms.DataGridViewComboBoxColumn()
+        Me.PkgStatus = New System.Windows.Forms.DataGridViewTextBoxColumn()
+        Me.PkgName = New System.Windows.Forms.DataGridViewTextBoxColumn()
+        Me.FriendlyName = New System.Windows.Forms.DataGridViewTextBoxColumn()
+        Me.AvailableVersion = New System.Windows.Forms.DataGridViewTextBoxColumn()
+        Me.LatestVersion = New System.Windows.Forms.DataGridViewTextBoxColumn()
+        Me.PkgDescription = New System.Windows.Forms.DataGridViewTextBoxColumn()
+        Me.Manifest = New System.Windows.Forms.DataGridViewTextBoxColumn()
         Me.menustripMainWindow.SuspendLayout()
         Me.contextmenustripPackageMenu.SuspendLayout()
         CType(Me.splitcontainerMainWindow, System.ComponentModel.ISupportInitialize).BeginInit()
@@ -410,70 +410,6 @@ Partial Class aaformMainWindow
         Me.datagridviewPackageList.Size = New System.Drawing.Size(829, 427)
         Me.datagridviewPackageList.StandardTab = True
         Me.datagridviewPackageList.TabIndex = 0
-        '
-        'PkgAction
-        '
-        Me.PkgAction.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCells
-        Me.PkgAction.HeaderText = "Action"
-        Me.PkgAction.Items.AddRange(New Object() {"Do nothing", "Install"})
-        Me.PkgAction.MinimumWidth = 6
-        Me.PkgAction.Name = "PkgAction"
-        Me.PkgAction.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Automatic
-        Me.PkgAction.Width = 76
-        '
-        'PkgStatus
-        '
-        Me.PkgStatus.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCells
-        Me.PkgStatus.HeaderText = "Status"
-        Me.PkgStatus.MinimumWidth = 6
-        Me.PkgStatus.Name = "PkgStatus"
-        Me.PkgStatus.ReadOnly = True
-        Me.PkgStatus.Width = 77
-        '
-        'PkgName
-        '
-        Me.PkgName.HeaderText = "Package"
-        Me.PkgName.MinimumWidth = 6
-        Me.PkgName.Name = "PkgName"
-        Me.PkgName.ReadOnly = True
-        '
-        'FriendlyName
-        '
-        Me.FriendlyName.HeaderText = "Name"
-        Me.FriendlyName.MinimumWidth = 6
-        Me.FriendlyName.Name = "FriendlyName"
-        Me.FriendlyName.ReadOnly = True
-        '
-        'AvailableVersion
-        '
-        Me.AvailableVersion.HeaderText = "Version"
-        Me.AvailableVersion.MinimumWidth = 6
-        Me.AvailableVersion.Name = "AvailableVersion"
-        Me.AvailableVersion.ReadOnly = True
-        Me.AvailableVersion.ToolTipText = "(will eventually only display latest version and have all older versions in a win" &
-    "dow like Synaptic)"
-        '
-        'LatestVersion
-        '
-        Me.LatestVersion.HeaderText = "Latest version"
-        Me.LatestVersion.MinimumWidth = 6
-        Me.LatestVersion.Name = "LatestVersion"
-        Me.LatestVersion.ReadOnly = True
-        '
-        'PkgDescription
-        '
-        Me.PkgDescription.HeaderText = "Description"
-        Me.PkgDescription.MinimumWidth = 6
-        Me.PkgDescription.Name = "PkgDescription"
-        Me.PkgDescription.ReadOnly = True
-        '
-        'Manifest
-        '
-        Me.Manifest.HeaderText = "Manifest"
-        Me.Manifest.MinimumWidth = 6
-        Me.Manifest.Name = "Manifest"
-        Me.Manifest.ReadOnly = True
-        Me.Manifest.Visible = False
         '
         'labelUpdatingPackageList
         '
@@ -895,6 +831,71 @@ Partial Class aaformMainWindow
         '
         Me.zSeparatorNoIdeaWhereThisIs.Name = "zSeparatorNoIdeaWhereThisIs"
         Me.zSeparatorNoIdeaWhereThisIs.Size = New System.Drawing.Size(210, 6)
+        '
+        'PkgAction
+        '
+        Me.PkgAction.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCells
+        Me.PkgAction.HeaderText = "Action"
+        Me.PkgAction.Items.AddRange(New Object() {"Do nothing", "Install"})
+        Me.PkgAction.MinimumWidth = 6
+        Me.PkgAction.Name = "PkgAction"
+        Me.PkgAction.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Automatic
+        Me.PkgAction.Width = 76
+        '
+        'PkgStatus
+        '
+        Me.PkgStatus.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCells
+        Me.PkgStatus.HeaderText = "Status"
+        Me.PkgStatus.MinimumWidth = 6
+        Me.PkgStatus.Name = "PkgStatus"
+        Me.PkgStatus.ReadOnly = True
+        Me.PkgStatus.Width = 77
+        '
+        'PkgName
+        '
+        Me.PkgName.HeaderText = "Package"
+        Me.PkgName.MinimumWidth = 6
+        Me.PkgName.Name = "PkgName"
+        Me.PkgName.ReadOnly = True
+        '
+        'FriendlyName
+        '
+        Me.FriendlyName.HeaderText = "Name"
+        Me.FriendlyName.MinimumWidth = 6
+        Me.FriendlyName.Name = "FriendlyName"
+        Me.FriendlyName.ReadOnly = True
+        '
+        'AvailableVersion
+        '
+        Me.AvailableVersion.HeaderText = "Version"
+        Me.AvailableVersion.MinimumWidth = 6
+        Me.AvailableVersion.Name = "AvailableVersion"
+        Me.AvailableVersion.ReadOnly = True
+        Me.AvailableVersion.ToolTipText = "(will eventually only display latest version and have all older versions in a win" &
+    "dow like Synaptic)"
+        '
+        'LatestVersion
+        '
+        Me.LatestVersion.HeaderText = "Latest version"
+        Me.LatestVersion.MinimumWidth = 6
+        Me.LatestVersion.Name = "LatestVersion"
+        Me.LatestVersion.ReadOnly = True
+        Me.LatestVersion.Visible = False
+        '
+        'PkgDescription
+        '
+        Me.PkgDescription.HeaderText = "Description"
+        Me.PkgDescription.MinimumWidth = 6
+        Me.PkgDescription.Name = "PkgDescription"
+        Me.PkgDescription.ReadOnly = True
+        '
+        'Manifest
+        '
+        Me.Manifest.HeaderText = "Manifest"
+        Me.Manifest.MinimumWidth = 6
+        Me.Manifest.Name = "Manifest"
+        Me.Manifest.ReadOnly = True
+        Me.Manifest.Visible = False
         '
         'aaformMainWindow
         '

--- a/guinget/MainWindow.Designer.vb
+++ b/guinget/MainWindow.Designer.vb
@@ -394,6 +394,7 @@ Partial Class aaformMainWindow
         Me.datagridviewPackageList.Location = New System.Drawing.Point(0, 0)
         Me.datagridviewPackageList.Margin = New System.Windows.Forms.Padding(2)
         Me.datagridviewPackageList.Name = "datagridviewPackageList"
+        Me.datagridviewPackageList.ReadOnly = True
         DataGridViewCellStyle3.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft
         DataGridViewCellStyle3.BackColor = System.Drawing.SystemColors.Control
         DataGridViewCellStyle3.Font = New System.Drawing.Font("Microsoft Sans Serif", 7.8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
@@ -418,6 +419,7 @@ Partial Class aaformMainWindow
         Me.PkgAction.Items.AddRange(New Object() {"Do nothing", "Install"})
         Me.PkgAction.MinimumWidth = 6
         Me.PkgAction.Name = "PkgAction"
+        Me.PkgAction.ReadOnly = True
         Me.PkgAction.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Automatic
         Me.PkgAction.Width = 76
         '
@@ -427,6 +429,7 @@ Partial Class aaformMainWindow
         Me.PkgStatus.HeaderText = "Status"
         Me.PkgStatus.MinimumWidth = 6
         Me.PkgStatus.Name = "PkgStatus"
+        Me.PkgStatus.ReadOnly = True
         Me.PkgStatus.Width = 77
         '
         'PkgName
@@ -434,18 +437,21 @@ Partial Class aaformMainWindow
         Me.PkgName.HeaderText = "Package"
         Me.PkgName.MinimumWidth = 6
         Me.PkgName.Name = "PkgName"
+        Me.PkgName.ReadOnly = True
         '
         'FriendlyName
         '
         Me.FriendlyName.HeaderText = "Name"
         Me.FriendlyName.MinimumWidth = 6
         Me.FriendlyName.Name = "FriendlyName"
+        Me.FriendlyName.ReadOnly = True
         '
         'AvailableVersion
         '
         Me.AvailableVersion.HeaderText = "Version"
         Me.AvailableVersion.MinimumWidth = 6
         Me.AvailableVersion.Name = "AvailableVersion"
+        Me.AvailableVersion.ReadOnly = True
         Me.AvailableVersion.ToolTipText = "(will eventually only display latest version and have all older versions in a win" &
     "dow like Synaptic)"
         '
@@ -454,18 +460,21 @@ Partial Class aaformMainWindow
         Me.LatestVersion.HeaderText = "Latest version"
         Me.LatestVersion.MinimumWidth = 6
         Me.LatestVersion.Name = "LatestVersion"
+        Me.LatestVersion.ReadOnly = True
         '
         'PkgDescription
         '
         Me.PkgDescription.HeaderText = "Description"
         Me.PkgDescription.MinimumWidth = 6
         Me.PkgDescription.Name = "PkgDescription"
+        Me.PkgDescription.ReadOnly = True
         '
         'Manifest
         '
         Me.Manifest.HeaderText = "Manifest"
         Me.Manifest.MinimumWidth = 6
         Me.Manifest.Name = "Manifest"
+        Me.Manifest.ReadOnly = True
         Me.Manifest.Visible = False
         '
         'labelUpdatingPackageList

--- a/guinget/MainWindow.resx
+++ b/guinget/MainWindow.resx
@@ -138,6 +138,9 @@
   <metadata name="AvailableVersion.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
+  <metadata name="LatestVersion.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
   <metadata name="PkgDescription.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
@@ -154,7 +157,7 @@
   <data name="toolstripbuttonRefreshCache.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAIDSURBVDhPpZLrS5NhGMb3j4SWh0oRQVExD4gonkDpg4hG
+        YQUAAAAJcEhZcwAAEnQAABJ0Ad5mH3gAAAIDSURBVDhPpZLrS5NhGMb3j4SWh0oRQVExD4gonkDpg4hG
         YKxG6WBogkMZKgPNCEVJFBGdGETEvgwyO9DJE5syZw3PIlPEE9pgBCLZ5XvdMB8Ew8gXbl54nuf63dd9
         0OGSnwCahxbPRNPAPMw9Xpg6ZmF46kZZ0xSKzJPIrhpDWsVnpBhGkKx3nAX8Pv7z1zg8OoY/cITdn4fw
         bf/C0kYAN3Ma/w3gWfZL5kzTKBxjWyK2DftwI9tyMYCZKXbNHaD91bLYJrDXsYbrWfUKwJrPE9M2M1Oc
@@ -169,7 +172,7 @@
   <data name="toolstripbuttonApplyChanges.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAIDSURBVDhPpZLrS5NhGMb3j4SWh0oRQVExD4gonkDpg4hG
+        YQUAAAAJcEhZcwAAEnQAABJ0Ad5mH3gAAAIDSURBVDhPpZLrS5NhGMb3j4SWh0oRQVExD4gonkDpg4hG
         YKxG6WBogkMZKgPNCEVJFBGdGETEvgwyO9DJE5syZw3PIlPEE9pgBCLZ5XvdMB8Ew8gXbl54nuf63dd9
         0OGSnwCahxbPRNPAPMw9Xpg6ZmF46kZZ0xSKzJPIrhpDWsVnpBhGkKx3nAX8Pv7z1zg8OoY/cITdn4fw
         bf/C0kYAN3Ma/w3gWfZL5kzTKBxjWyK2DftwI9tyMYCZKXbNHaD91bLYJrDXsYbrWfUKwJrPE9M2M1Oc
@@ -184,7 +187,7 @@
   <data name="toolstripbuttonProperties.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAIDSURBVDhPpZLrS5NhGMb3j4SWh0oRQVExD4gonkDpg4hG
+        YQUAAAAJcEhZcwAAEnQAABJ0Ad5mH3gAAAIDSURBVDhPpZLrS5NhGMb3j4SWh0oRQVExD4gonkDpg4hG
         YKxG6WBogkMZKgPNCEVJFBGdGETEvgwyO9DJE5syZw3PIlPEE9pgBCLZ5XvdMB8Ew8gXbl54nuf63dd9
         0OGSnwCahxbPRNPAPMw9Xpg6ZmF46kZZ0xSKzJPIrhpDWsVnpBhGkKx3nAX8Pv7z1zg8OoY/cITdn4fw
         bf/C0kYAN3Ma/w3gWfZL5kzTKBxjWyK2DftwI9tyMYCZKXbNHaD91bLYJrDXsYbrWfUKwJrPE9M2M1Oc
@@ -199,7 +202,7 @@
   <data name="toolstripsplitbuttonSearch.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAIDSURBVDhPpZLrS5NhGMb3j4SWh0oRQVExD4gonkDpg4hG
+        YQUAAAAJcEhZcwAAEnQAABJ0Ad5mH3gAAAIDSURBVDhPpZLrS5NhGMb3j4SWh0oRQVExD4gonkDpg4hG
         YKxG6WBogkMZKgPNCEVJFBGdGETEvgwyO9DJE5syZw3PIlPEE9pgBCLZ5XvdMB8Ew8gXbl54nuf63dd9
         0OGSnwCahxbPRNPAPMw9Xpg6ZmF46kZZ0xSKzJPIrhpDWsVnpBhGkKx3nAX8Pv7z1zg8OoY/cITdn4fw
         bf/C0kYAN3Ma/w3gWfZL5kzTKBxjWyK2DftwI9tyMYCZKXbNHaD91bLYJrDXsYbrWfUKwJrPE9M2M1Oc

--- a/guinget/MainWindow.vb
+++ b/guinget/MainWindow.vb
@@ -193,10 +193,8 @@ Public Class aaformMainWindow
         Next
 
         For Each PackageRow As DataGridViewRow In aaformMainWindow.datagridviewPackageList.Rows
-            If Not PackageRow.Cells.Item(4).Value.ToString = PackageRow.Cells.Item(5).Value.ToString Then
-                PackageRow.Visible = False
-            Else
-                PackageRow.Visible = True
+            If My.Settings.OnlyDisplayLatestPackageVersion = True AndAlso Not PackageRow.Cells.Item(4).Value.ToString = PackageRow.Cells.Item(5).Value.ToString Then
+                aaformMainWindow.datagridviewPackageList.Rows.Remove(PackageRow)
             End If
         Next
 

--- a/guinget/MainWindow.vb
+++ b/guinget/MainWindow.vb
@@ -75,7 +75,7 @@ Public Class aaformMainWindow
         aaformMainWindow.Update()
 
         ' Now we populate the Manifest column with each manifest.
-        Dim ManifestPaths() As String = PackageListTools.GetManifests.TrimEnd.Split(CType("?", Char()))
+        Dim ManifestPaths As List(Of String) = PackageListTools.GetManifests
 
         ' Set progress bar maximum and step count.
         aaformMainWindow.toolstripprogressbarLoadingPackages.Maximum = ManifestPaths.Count - 1
@@ -98,7 +98,7 @@ Public Class aaformMainWindow
         ' Go through everything in the manifest paths array until it's out if
         ' we don't want to load from a database.
         If My.Settings.LoadFromSqliteDb = False Then
-            For i As Integer = 0 To ManifestPaths.Count - 2
+            For i As Integer = 0 To ManifestPaths.Count - 1
 
                 ' Read the file into the manifest column and make a new row with it.
                 aaformMainWindow.datagridviewPackageList.Rows.Add("Do nothing", "Unknown", "Loading...", "Loading...", "Loading...", "Unknown", "Loading...", ManifestPaths(i))
@@ -166,7 +166,7 @@ Public Class aaformMainWindow
             ' These have to be grabbed now or else updating the manifests
             ' will crash when the path doesn't exist.
         ElseIf My.Settings.LoadFromSqliteDb = True Then
-            PackageListTools.FallbackPathList = PackageListTools.GetManifests.TrimEnd.Split(CType("?", Char()))
+            PackageListTools.FallbackPathList = PackageListTools.GetManifests
 
             ' Now we need to load the manifests and the descriptions.
             For Each PackageRow As DataGridViewRow In aaformMainWindow.datagridviewPackageList.Rows

--- a/guinget/MainWindow.vb
+++ b/guinget/MainWindow.vb
@@ -114,7 +114,7 @@ Public Class aaformMainWindow
             'MessageBox.Show(SqliteList.Rows.Item(0).ToString)
             'aaformMainWindow.datagridviewPackageList.DataSource = SqliteList
             For Each PackageRow As DataRow In SqliteList.Rows
-                aaformMainWindow.datagridviewPackageList.Rows.Add("Do nothing", "Unknown", PackageRow.Item(0), PackageRow.Item(1), PackageRow.Item(2), "Loading...", "Loading...")
+                aaformMainWindow.datagridviewPackageList.Rows.Add("Do nothing", "Unknown", PackageRow.Item(0), PackageRow.Item(1), PackageRow.Item(2), PackageRow.Item(3), "Loading...", "Loading...")
 
                 ' Make the progress bar progress.
                 aaformMainWindow.toolstripprogressbarLoadingPackages.PerformStep()
@@ -161,9 +161,9 @@ Public Class aaformMainWindow
             ' Now we need to load the manifests and the descriptions.
             For Each PackageRow As DataGridViewRow In aaformMainWindow.datagridviewPackageList.Rows
                 ' Find the manifest and get its description.
-                PackageRow.Cells.Item(6).Value = Await PackageListTools.FindManifestByVersionAndId(PackageRow.Cells.Item(2).Value.ToString, PackageRow.Cells.Item(4).Value.ToString)
+                PackageRow.Cells.Item(7).Value = Await PackageListTools.FindManifestByVersionAndId(PackageRow.Cells.Item(2).Value.ToString, PackageRow.Cells.Item(4).Value.ToString)
 
-                PackageRow.Cells.Item(5).Value = Await PackageTools.GetPackageInfoFromYamlAsync(PackageRow.Cells.Item(6).Value.ToString, "Description")
+                PackageRow.Cells.Item(6).Value = Await PackageTools.GetPackageInfoFromYamlAsync(PackageRow.Cells.Item(7).Value.ToString, "Description")
                 ' Make the progress bar progress.
                 aaformMainWindow.toolstripprogressbarLoadingPackages.Value = PackageRow.Index
                 ' Update the statusbar to show the current info.
@@ -187,6 +187,14 @@ Public Class aaformMainWindow
 
         ' Reset progress bar to 0.
         aaformMainWindow.toolstripprogressbarLoadingPackages.Value = 0
+
+        For Each PackageRow As DataGridViewRow In aaformMainWindow.datagridviewPackageList.Rows
+            If Not PackageRow.Cells.Item(2).Value.ToString = PackageRow.Cells.Item(3).Value.ToString Then
+                PackageRow.Visible = False
+            Else
+                PackageRow.Visible = True
+            End If
+        Next
 
         ' Update the main window again.
         aaformMainWindow.Update()

--- a/guinget/MainWindow.vb
+++ b/guinget/MainWindow.vb
@@ -115,11 +115,16 @@ Public Class aaformMainWindow
             'aaformMainWindow.datagridviewPackageList.DataSource = SqliteList
             For Each PackageRow As DataRow In SqliteList.Rows
                 If My.Settings.OnlyDisplayLatestPackageVersion = True Then
+                    ' If the user wants to only display the latest package version,
+                    ' we'll have to compare it.
                     If PackageRow.Item(2).ToString = PackageRow.Item(3).ToString Then
+                        ' Only add the package to the list if the package row we're looking
+                        ' at is the latest version of the package.
                         aaformMainWindow.datagridviewPackageList.Rows.Add("Do nothing", "Unknown", PackageRow.Item(0), PackageRow.Item(1), PackageRow.Item(2), PackageRow.Item(3), "Loading...", "Loading...")
                     End If
                 Else
-                        aaformMainWindow.datagridviewPackageList.Rows.Add("Do nothing", "Unknown", PackageRow.Item(0), PackageRow.Item(1), PackageRow.Item(2), PackageRow.Item(3), "Loading...", "Loading...")
+                    ' Just add all the package versions.
+                    aaformMainWindow.datagridviewPackageList.Rows.Add("Do nothing", "Unknown", PackageRow.Item(0), PackageRow.Item(1), PackageRow.Item(2), PackageRow.Item(3), "Loading...", "Loading...")
                 End If
                 ' Make the progress bar progress.
                 aaformMainWindow.toolstripprogressbarLoadingPackages.PerformStep()
@@ -192,23 +197,6 @@ Public Class aaformMainWindow
 
         ' Reset progress bar to 0.
         aaformMainWindow.toolstripprogressbarLoadingPackages.Value = 0
-
-        'If My.Settings.OnlyDisplayLatestPackageVersion = True Then
-
-        '    For Each column As DataGridViewColumn In aaformMainWindow.datagridviewPackageList.Columns
-        '        column.AutoSizeMode = DataGridViewAutoSizeColumnMode.NotSet
-        '    Next
-
-        '    For Each PackageRow As DataGridViewRow In aaformMainWindow.datagridviewPackageList.Rows
-        '        If Not PackageRow.Cells.Item(4).Value.ToString = PackageRow.Cells.Item(5).Value.ToString Then
-        '            'MessageBox.Show(PackageRow.Cells.Item(2).Value.ToString & ":" & vbCrLf &
-        '            '                "Outdated version: " & PackageRow.Cells.Item(4).Value.ToString & vbCrLf &
-        '            '                "Latest version: " & PackageRow.Cells.Item(5).Value.ToString)
-        '            aaformMainWindow.datagridviewPackageList.Rows.Remove(PackageRow)
-        '        End If
-        '    Next
-
-        'End If
 
         ' Update the main window again.
         aaformMainWindow.Update()

--- a/guinget/MainWindow.vb
+++ b/guinget/MainWindow.vb
@@ -188,8 +188,12 @@ Public Class aaformMainWindow
         ' Reset progress bar to 0.
         aaformMainWindow.toolstripprogressbarLoadingPackages.Value = 0
 
+        For Each column As DataGridViewColumn In aaformMainWindow.datagridviewPackageList.Columns
+            column.AutoSizeMode = DataGridViewAutoSizeColumnMode.NotSet
+        Next
+
         For Each PackageRow As DataGridViewRow In aaformMainWindow.datagridviewPackageList.Rows
-            If Not PackageRow.Cells.Item(2).Value.ToString = PackageRow.Cells.Item(3).Value.ToString Then
+            If Not PackageRow.Cells.Item(4).Value.ToString = PackageRow.Cells.Item(5).Value.ToString Then
                 PackageRow.Visible = False
             Else
                 PackageRow.Visible = True

--- a/guinget/MainWindow.vb
+++ b/guinget/MainWindow.vb
@@ -188,15 +188,19 @@ Public Class aaformMainWindow
         ' Reset progress bar to 0.
         aaformMainWindow.toolstripprogressbarLoadingPackages.Value = 0
 
-        For Each column As DataGridViewColumn In aaformMainWindow.datagridviewPackageList.Columns
-            column.AutoSizeMode = DataGridViewAutoSizeColumnMode.NotSet
-        Next
+        If My.Settings.OnlyDisplayLatestPackageVersion = True Then
 
-        For Each PackageRow As DataGridViewRow In aaformMainWindow.datagridviewPackageList.Rows
-            If My.Settings.OnlyDisplayLatestPackageVersion = True AndAlso Not PackageRow.Cells.Item(4).Value.ToString = PackageRow.Cells.Item(5).Value.ToString Then
-                aaformMainWindow.datagridviewPackageList.Rows.Remove(PackageRow)
-            End If
-        Next
+            For Each column As DataGridViewColumn In aaformMainWindow.datagridviewPackageList.Columns
+                column.AutoSizeMode = DataGridViewAutoSizeColumnMode.NotSet
+            Next
+
+            For Each PackageRow As DataGridViewRow In aaformMainWindow.datagridviewPackageList.Rows
+                If Not PackageRow.Cells.Item(4).Value.ToString = PackageRow.Cells.Item(5).Value.ToString Then
+                    aaformMainWindow.datagridviewPackageList.Rows.Remove(PackageRow)
+                End If
+            Next
+
+        End If
 
         ' Update the main window again.
         aaformMainWindow.Update()

--- a/guinget/MainWindow.vb
+++ b/guinget/MainWindow.vb
@@ -117,7 +117,7 @@ Public Class aaformMainWindow
                 If My.Settings.OnlyDisplayLatestPackageVersion = True Then
                     ' If the user wants to only display the latest package version,
                     ' we'll have to compare it.
-                    If PackageRow.Item(2).ToString = PackageRow.Item(3).ToString Then
+                    If PackageRow.Item(4).ToString = PackageRow.Item(5).ToString Then
                         ' Only add the package to the list if the package row we're looking
                         ' at is the latest version of the package.
                         aaformMainWindow.datagridviewPackageList.Rows.Add("Do nothing", "Unknown", PackageRow.Item(0), PackageRow.Item(1), PackageRow.Item(2), PackageRow.Item(3), "Loading...", "Loading...")

--- a/guinget/MainWindow.vb
+++ b/guinget/MainWindow.vb
@@ -117,7 +117,7 @@ Public Class aaformMainWindow
                 If My.Settings.OnlyDisplayLatestPackageVersion = True Then
                     ' If the user wants to only display the latest package version,
                     ' we'll have to compare it.
-                    If PackageRow.Item(4).ToString = PackageRow.Item(5).ToString Then
+                    If PackageRow.Item(2).ToString = PackageRow.Item(3).ToString Then
                         ' Only add the package to the list if the package row we're looking
                         ' at is the latest version of the package.
                         aaformMainWindow.datagridviewPackageList.Rows.Add("Do nothing", "Unknown", PackageRow.Item(0), PackageRow.Item(1), PackageRow.Item(2), PackageRow.Item(3), "Loading...", "Loading...")

--- a/guinget/MainWindow.vb
+++ b/guinget/MainWindow.vb
@@ -365,13 +365,13 @@ Public Class aaformMainWindow
 
     Private Sub datagridviewPackageList_SelectionChanged(sender As Object, e As EventArgs) Handles datagridviewPackageList.SelectionChanged
         ' Get package details if only one package is selected.
-        If datagridviewPackageList.SelectedRows.Count = 1 AndAlso IO.File.Exists(datagridviewPackageList.SelectedRows.Item(0).Cells(6).Value.ToString) Then
+        If datagridviewPackageList.SelectedRows.Count = 1 AndAlso IO.File.Exists(datagridviewPackageList.SelectedRows.Item(0).Cells(7).Value.ToString) Then
             ' If only one is selected, get its details into the details textbox.
             ' Set the textbox to say "Loading..." so it doesn't look like it's hanging.
             textboxPackageDetails.Text = "Loading, please wait..."
             ' Take text from the Manifest cell and use that
             ' file path to display text in the details textbox.
-            Dim ManifestPath As String = datagridviewPackageList.Item(6, datagridviewPackageList.SelectedRows.Item(0).Index).Value.ToString
+            Dim ManifestPath As String = datagridviewPackageList.Item(7, datagridviewPackageList.SelectedRows.Item(0).Index).Value.ToString
             ' Display full manifest in details textbox.
             textboxPackageDetails.Text = My.Computer.FileSystem.ReadAllText(ManifestPath).Replace(vbLf, vbCrLf)
         ElseIf datagridviewPackageList.SelectedRows.Count = 0 Then

--- a/guinget/MainWindow.vb
+++ b/guinget/MainWindow.vb
@@ -101,7 +101,7 @@ Public Class aaformMainWindow
             For i As Integer = 0 To ManifestPaths.Count - 2
 
                 ' Read the file into the manifest column and make a new row with it.
-                aaformMainWindow.datagridviewPackageList.Rows.Add("Do nothing", "Unknown", "Loading...", "Loading...", "Loading...", "Loading...", ManifestPaths(i))
+                aaformMainWindow.datagridviewPackageList.Rows.Add("Do nothing", "Unknown", "Loading...", "Loading...", "Loading...", "Unknown", "Loading...", ManifestPaths(i))
 
                 ' Make the progress bar progress.
                 aaformMainWindow.toolstripprogressbarLoadingPackages.Value = i
@@ -149,13 +149,13 @@ Public Class aaformMainWindow
         If My.Settings.LoadFromSqliteDb = False Then
             For Each Row As DataGridViewRow In aaformMainWindow.datagridviewPackageList.Rows
                 ' Load package ID column.
-                Row.Cells.Item(2).Value = Await PackageTools.GetPackageInfoFromYamlAsync(Row.Cells.Item(6).Value.ToString, "Id")
+                Row.Cells.Item(2).Value = Await PackageTools.GetPackageInfoFromYamlAsync(Row.Cells.Item(7).Value.ToString, "Id")
                 ' Load package name column.
-                Row.Cells.Item(3).Value = Await PackageTools.GetPackageInfoFromYamlAsync(Row.Cells.Item(6).Value.ToString, "Name")
+                Row.Cells.Item(3).Value = Await PackageTools.GetPackageInfoFromYamlAsync(Row.Cells.Item(7).Value.ToString, "Name")
                 ' Load package version column.
-                Row.Cells.Item(4).Value = Await PackageTools.GetPackageInfoFromYamlAsync(Row.Cells.Item(6).Value.ToString, "Version")
+                Row.Cells.Item(4).Value = Await PackageTools.GetPackageInfoFromYamlAsync(Row.Cells.Item(7).Value.ToString, "Version")
                 ' Load package description column.
-                Row.Cells.Item(5).Value = Await PackageTools.GetPackageInfoFromYamlAsync(Row.Cells.Item(6).Value.ToString, "Description")
+                Row.Cells.Item(6).Value = Await PackageTools.GetPackageInfoFromYamlAsync(Row.Cells.Item(7).Value.ToString, "Description")
                 ' Update the progressbar so it doesn't look frozen.
                 aaformMainWindow.toolstripprogressbarLoadingPackages.Value = Row.Index
                 aaformMainWindow.statusbarMainWindow.Update()

--- a/guinget/MainWindow.vb
+++ b/guinget/MainWindow.vb
@@ -114,8 +114,13 @@ Public Class aaformMainWindow
             'MessageBox.Show(SqliteList.Rows.Item(0).ToString)
             'aaformMainWindow.datagridviewPackageList.DataSource = SqliteList
             For Each PackageRow As DataRow In SqliteList.Rows
-                aaformMainWindow.datagridviewPackageList.Rows.Add("Do nothing", "Unknown", PackageRow.Item(0), PackageRow.Item(1), PackageRow.Item(2), PackageRow.Item(3), "Loading...", "Loading...")
-
+                If My.Settings.OnlyDisplayLatestPackageVersion = True Then
+                    If PackageRow.Item(2).ToString = PackageRow.Item(3).ToString Then
+                        aaformMainWindow.datagridviewPackageList.Rows.Add("Do nothing", "Unknown", PackageRow.Item(0), PackageRow.Item(1), PackageRow.Item(2), PackageRow.Item(3), "Loading...", "Loading...")
+                    End If
+                Else
+                        aaformMainWindow.datagridviewPackageList.Rows.Add("Do nothing", "Unknown", PackageRow.Item(0), PackageRow.Item(1), PackageRow.Item(2), PackageRow.Item(3), "Loading...", "Loading...")
+                End If
                 ' Make the progress bar progress.
                 aaformMainWindow.toolstripprogressbarLoadingPackages.PerformStep()
                 ' Update the statusbar to show the current info.
@@ -188,19 +193,22 @@ Public Class aaformMainWindow
         ' Reset progress bar to 0.
         aaformMainWindow.toolstripprogressbarLoadingPackages.Value = 0
 
-        If My.Settings.OnlyDisplayLatestPackageVersion = True Then
+        'If My.Settings.OnlyDisplayLatestPackageVersion = True Then
 
-            For Each column As DataGridViewColumn In aaformMainWindow.datagridviewPackageList.Columns
-                column.AutoSizeMode = DataGridViewAutoSizeColumnMode.NotSet
-            Next
+        '    For Each column As DataGridViewColumn In aaformMainWindow.datagridviewPackageList.Columns
+        '        column.AutoSizeMode = DataGridViewAutoSizeColumnMode.NotSet
+        '    Next
 
-            For Each PackageRow As DataGridViewRow In aaformMainWindow.datagridviewPackageList.Rows
-                If Not PackageRow.Cells.Item(4).Value.ToString = PackageRow.Cells.Item(5).Value.ToString Then
-                    aaformMainWindow.datagridviewPackageList.Rows.Remove(PackageRow)
-                End If
-            Next
+        '    For Each PackageRow As DataGridViewRow In aaformMainWindow.datagridviewPackageList.Rows
+        '        If Not PackageRow.Cells.Item(4).Value.ToString = PackageRow.Cells.Item(5).Value.ToString Then
+        '            'MessageBox.Show(PackageRow.Cells.Item(2).Value.ToString & ":" & vbCrLf &
+        '            '                "Outdated version: " & PackageRow.Cells.Item(4).Value.ToString & vbCrLf &
+        '            '                "Latest version: " & PackageRow.Cells.Item(5).Value.ToString)
+        '            aaformMainWindow.datagridviewPackageList.Rows.Remove(PackageRow)
+        '        End If
+        '    Next
 
-        End If
+        'End If
 
         ' Update the main window again.
         aaformMainWindow.Update()

--- a/guinget/My Project/Settings.Designer.vb
+++ b/guinget/My Project/Settings.Designer.vb
@@ -197,6 +197,18 @@ Namespace My
                 Me("DebuggingBypassCacheUpdate") = value
             End Set
         End Property
+        
+        <Global.System.Configuration.UserScopedSettingAttribute(),  _
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
+         Global.System.Configuration.DefaultSettingValueAttribute("True")>  _
+        Public Property HideOlderPackageVersions() As Boolean
+            Get
+                Return CType(Me("HideOlderPackageVersions"),Boolean)
+            End Get
+            Set
+                Me("HideOlderPackageVersions") = value
+            End Set
+        End Property
     End Class
 End Namespace
 

--- a/guinget/My Project/Settings.Designer.vb
+++ b/guinget/My Project/Settings.Designer.vb
@@ -201,12 +201,12 @@ Namespace My
         <Global.System.Configuration.UserScopedSettingAttribute(),  _
          Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
          Global.System.Configuration.DefaultSettingValueAttribute("True")>  _
-        Public Property HideOlderPackageVersions() As Boolean
+        Public Property OnlyDisplayLatestPackageVersion() As Boolean
             Get
-                Return CType(Me("HideOlderPackageVersions"),Boolean)
+                Return CType(Me("OnlyDisplayLatestPackageVersion"),Boolean)
             End Get
             Set
-                Me("HideOlderPackageVersions") = value
+                Me("OnlyDisplayLatestPackageVersion") = value
             End Set
         End Property
     End Class

--- a/guinget/My Project/Settings.Designer.vb
+++ b/guinget/My Project/Settings.Designer.vb
@@ -200,7 +200,7 @@ Namespace My
         
         <Global.System.Configuration.UserScopedSettingAttribute(),  _
          Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
-         Global.System.Configuration.DefaultSettingValueAttribute("True")>  _
+         Global.System.Configuration.DefaultSettingValueAttribute("False")>  _
         Public Property OnlyDisplayLatestPackageVersion() As Boolean
             Get
                 Return CType(Me("OnlyDisplayLatestPackageVersion"),Boolean)

--- a/guinget/My Project/Settings.settings
+++ b/guinget/My Project/Settings.settings
@@ -38,7 +38,7 @@
     <Setting Name="DebuggingBypassCacheUpdate" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
-    <Setting Name="HideOlderPackageVersions" Type="System.Boolean" Scope="User">
+    <Setting Name="OnlyDisplayLatestPackageVersion" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">True</Value>
     </Setting>
   </Settings>

--- a/guinget/My Project/Settings.settings
+++ b/guinget/My Project/Settings.settings
@@ -39,7 +39,7 @@
       <Value Profile="(Default)">False</Value>
     </Setting>
     <Setting Name="OnlyDisplayLatestPackageVersion" Type="System.Boolean" Scope="User">
-      <Value Profile="(Default)">True</Value>
+      <Value Profile="(Default)">False</Value>
     </Setting>
   </Settings>
 </SettingsFile>

--- a/guinget/My Project/Settings.settings
+++ b/guinget/My Project/Settings.settings
@@ -38,5 +38,8 @@
     <Setting Name="DebuggingBypassCacheUpdate" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
+    <Setting Name="HideOlderPackageVersions" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">True</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/libguinget/PackageListTools.vb
+++ b/libguinget/PackageListTools.vb
@@ -438,14 +438,14 @@ Public Class PackageListTools
 
     End Function
 
-    Public Shared Function GetManifests() As String
+    Public Shared Function GetManifests() As List(Of String)
         ' Get and return each manifest in the manifests folder.
         ' This should only be used after ensuring that there's
         ' stuff in this folder, or it'll crash.
         Dim ManifestAppDataFolder As String = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData) & "\winget-frontends\source\winget-pkgs\pkglist\manifests"
 
         ' Define a variable so we can store the manifest paths.
-        Dim ManifestPath As String = String.Empty
+        Dim ManifestPath As List(Of String) = New List(Of String)
 
         ' Take the Id string for each package file and append it to the
         ' package list array variable.
@@ -453,7 +453,7 @@ Public Class PackageListTools
 
             ' Append the current package manifest's path to the ManifestPath string.
             ' Using a question mark since it's not allowed in path names.
-            ManifestPath = ManifestPath & PackageManifest & "?"
+            ManifestPath.Add(PackageManifest)
         Next
 
         Return ManifestPath
@@ -464,7 +464,7 @@ Public Class PackageListTools
     ' If the folder used here doesn't exist, applications using this
     ' library will crash, so it has to be set by the calling application before
     ' being used.
-    Public Shared FallbackPathList() As String
+    Public Shared FallbackPathList As List(Of String)
 
     Public Shared Async Function FindManifestByVersionAndId(ManifestId As String, ManifestVersion As String) As Task(Of String)
         ' We'll look through the manifests in the cache, and if there's a version number match,

--- a/libguinget/PackageListTools.vb
+++ b/libguinget/PackageListTools.vb
@@ -521,6 +521,9 @@ Public Class PackageListTools
             " names where manifest.id = ids._rowid_ and manifest.version = versions._rowid_ " &
             " and manifest.name = names._rowid_ order by ids.id;"
 
+        ' SQL query for latest package version.
+        ' Based on the code at the bottom of this page:
+        ' https://www.sqlitetutorial.net/sqlite-window-functions/sqlite-last_value/#:~:text=The%20LAST_VALUE%20%28%29%20is%20a%20window%20function%20that,LAST_VALUE%20%28expression%29%20OVER%20%28%20PARTITION%20BY%20expression1%2C%20expression2%2C
         Dim SqlQueryWithLatestVersion As String = "SELECT DISTINCT
     ids.id, manifest.id, versions.version, manifest.version, names.name, manifest.name,
     LAST_VALUE ( versions.version ) OVER (


### PR DESCRIPTION
The latest version of a package can now be displayed in its own column (currently hard-coded to be hidden). Optionally, the latest version can be the only version that's loaded, but some packages such as `AdoptOpenJDK.OpenJDK` have an issue with this right now where the version that's displayed as the "latest" is actually an older version due to that being the last version added to the database. Additionally, this feature requires loading from the database to be on for it to do anything useful. Please be aware that **this is an experimental feature** and isn't ready to be used all the time.

Other changes and details:
- New **experimental** setting added
  - `OnlyDisplayLatestPackageVersion`. Boolean; defaults to `False`
  - If we're loading from the database, this will make it so that only the latest version of a package is shown in the list. As mentioned above, it's not reliable yet and sometimes displays the wrong version as the latest.
  - `libguinget.GetPackageDetailsTableFromSqliteDB` now returns four items, with the fourth one being what it thinks is the latest version.
  - Although I'm pretty sure no-one else is using `libguinget` yet, this may impact people using it. Not entirely sure what happens if you don't use all four items, though.
- Instead of concatenating a `String`, we're now using a `List(Of String)` to store the manifest paths.
  - This reduces complexity and makes it so that we don't have to split the string before using it.
  - As a side effect, there's only one thing that has to be removed when looping through the manifest paths list instead of two (`...To ManifestPaths.Count - 1` instead of `...To ManifestPaths.Count - 2`).
  - Again, this will impact people using `libguinget` if anyone else is using it, so they'll have to modify their code if they update `libguinget` when this version is out.