### PR TITLE
Allow bulk-installing packages.

### DIFF
--- a/guinget/ApplyChangesWindow.vb
+++ b/guinget/ApplyChangesWindow.vb
@@ -56,7 +56,7 @@ Public Class ApplyChangesWindow
             PackageIDs.Add(Package.Cells(0).Value.ToString)
             PackageVersions.Add(Package.Cells(1).Value.ToString)
         Next
-        PackageTools.BulkInstallPkg(datagridviewAppsBeingInstalled.Columns(0))
+        PackageTools.BulkInstallPkg(PackageIDs, PackageVersions, My.Settings.InstallInteractively)
     End Sub
 
     Private Sub InstallSinglePackage()

--- a/guinget/ApplyChangesWindow.vb
+++ b/guinget/ApplyChangesWindow.vb
@@ -45,12 +45,9 @@ Public Class ApplyChangesWindow
     End Sub
 
     Private Sub buttonConfirmChanges_Click(sender As Object, e As EventArgs) Handles buttonConfirmChanges.Click
-        ' Show a messagebox that says we don't support batch installs yet, and
-        ' ask the user to double-click or press Enter on each of the packages
-        ' when they're ready to start installing them.
-        MessageBox.Show("Sorry, we don't support automatic batch package installs yet, but you can double-click or press Enter" &
-                        " on each package in the list to install them individually when you're ready.", "Confirm changes")
-
+        ' Begin bulk-install process.
+        ' Needs to be updated to check for packages the user wants to
+        ' have uninstalled in the future when that's supported.
         BulkInstallPackages()
     End Sub
 

--- a/guinget/ApplyChangesWindow.vb
+++ b/guinget/ApplyChangesWindow.vb
@@ -50,13 +50,32 @@ Public Class ApplyChangesWindow
         ' when they're ready to start installing them.
         MessageBox.Show("Sorry, we don't support automatic batch package installs yet, but you can double-click or press Enter" &
                         " on each package in the list to install them individually when you're ready.", "Confirm changes")
-        Dim PackageIDs As New List(Of String)
-        Dim PackageVersions As New List(Of String)
-        For Each Package As DataGridViewRow In datagridviewAppsBeingInstalled.Rows
-            PackageIDs.Add(Package.Cells(0).Value.ToString)
-            PackageVersions.Add(Package.Cells(1).Value.ToString)
-        Next
-        PackageTools.BulkInstallPkg(PackageIDs, PackageVersions, My.Settings.InstallInteractively)
+
+        BulkInstallPackages()
+    End Sub
+
+    Private Sub BulkInstallPackages()
+        ' First make sure there are packages in the list.
+        If datagridviewAppsBeingInstalled.Rows.Count > 0 Then
+            ' Make sure we're not already installing by blocking out the "Confirm changes" button.
+            buttonConfirmChanges.Enabled = False
+
+            ' Change all the packages to say "Installing..."
+            For Each Package As DataGridViewRow In datagridviewAppsBeingInstalled.Rows
+                Package.Cells.Item(3).Value = Package.Cells.Item(2).Value.ToString & "ing..."
+            Next
+
+            ' Now we can start the install process.
+            Dim PackageIDs As New List(Of String)
+            Dim PackageVersions As New List(Of String)
+            ' Go through the datagridview and add the packages to the list.
+            For Each Package As DataGridViewRow In datagridviewAppsBeingInstalled.Rows
+                PackageIDs.Add(Package.Cells(0).Value.ToString)
+                PackageVersions.Add(Package.Cells(1).Value.ToString)
+            Next
+            ' Send the lists over to the bulk install code.
+            PackageTools.BulkInstallPkg(PackageIDs, PackageVersions, My.Settings.InstallInteractively)
+        End If
     End Sub
 
     Private Sub InstallSinglePackage()

--- a/guinget/ApplyChangesWindow.vb
+++ b/guinget/ApplyChangesWindow.vb
@@ -50,6 +50,13 @@ Public Class ApplyChangesWindow
         ' when they're ready to start installing them.
         MessageBox.Show("Sorry, we don't support automatic batch package installs yet, but you can double-click or press Enter" &
                         " on each package in the list to install them individually when you're ready.", "Confirm changes")
+        Dim PackageIDs As New List(Of String)
+        Dim PackageVersions As New List(Of String)
+        For Each Package As DataGridViewRow In datagridviewAppsBeingInstalled.Rows
+            PackageIDs.Add(Package.Cells(0).Value.ToString)
+            PackageVersions.Add(Package.Cells(1).Value.ToString)
+        Next
+        PackageTools.BulkInstallPkg(datagridviewAppsBeingInstalled.Columns(0))
     End Sub
 
     Private Sub InstallSinglePackage()

--- a/libguinget/PackageTools.vb
+++ b/libguinget/PackageTools.vb
@@ -71,13 +71,11 @@ Public Class PackageTools
 
             ' Define CMD args by going through the list of packages.
             ' Be sure to only add && if there are packages left to add.
-            Dim BulkInstallCommandList As String = "/k "
-            For Each Package As String In PackageIDs
-                For Each Version As String In PackageVersions
-                    ' Begin adding packages to the list.
-                    BulkInstallCommandList = "winget install --id " & Package & " -v " & Version & InteractiveFlag & " -e"
-                    '
-                Next
+            Dim BulkInstallCommandList As String = String.Empty
+            For i As Integer = 0 To PackageIDs.Count - 1
+                ' Begin adding packages to the list.
+                BulkInstallCommandList = BulkInstallCommandList & "winget install --id " & PackageIDs(i) & " -v " & PackageVersions(i) & InteractiveFlag & " -e"
+                '
             Next
 
             MessageBox.Show(BulkInstallCommandList.ToString)

--- a/libguinget/PackageTools.vb
+++ b/libguinget/PackageTools.vb
@@ -75,7 +75,10 @@ Public Class PackageTools
             For i As Integer = 0 To PackageIDs.Count - 1
                 ' Begin adding packages to the list.
                 BulkInstallCommandList = BulkInstallCommandList & "winget install --id " & PackageIDs(i) & " -v " & PackageVersions(i) & InteractiveFlag & " -e"
-                '
+                ' Now see if we should add " && ".
+                If i < PackageIDs.Count - 1 Then
+                    BulkInstallCommandList = BulkInstallCommandList & " && "
+                End If
             Next
 
             MessageBox.Show(BulkInstallCommandList.ToString)

--- a/libguinget/PackageTools.vb
+++ b/libguinget/PackageTools.vb
@@ -82,6 +82,12 @@ Public Class PackageTools
             Next
 
             MessageBox.Show(BulkInstallCommandList.ToString)
+
+            ' Define args for running winget and CMD.
+            proc.StartInfo.Arguments = "/k " & BulkInstallCommandList
+
+            ' Start installing.
+            proc.Start()
         End Using
     End Sub
 #End Region

--- a/libguinget/PackageTools.vb
+++ b/libguinget/PackageTools.vb
@@ -81,8 +81,6 @@ Public Class PackageTools
                 End If
             Next
 
-            MessageBox.Show(BulkInstallCommandList.ToString)
-
             ' Define args for running winget and CMD.
             proc.StartInfo.Arguments = "/k " & BulkInstallCommandList
 

--- a/libguinget/PackageTools.vb
+++ b/libguinget/PackageTools.vb
@@ -76,8 +76,11 @@ Public Class PackageTools
                 For Each Version As String In PackageVersions
                     ' Begin adding packages to the list.
                     BulkInstallCommandList = "winget install --id " & Package & " -v " & Version & InteractiveFlag & " -e"
+                    '
                 Next
             Next
+
+            MessageBox.Show(BulkInstallCommandList.ToString)
         End Using
     End Sub
 #End Region


### PR DESCRIPTION
It's now possible to click the `Confirm changes` button in the `Apply Changes` window and have all the packages listed for installation be passed directly to winget for installation instead of manually double-clicking on them individually. Makes installing stuff way faster and smoother during testing.