### PR TITLE
Move root form progress dialog thing into its own form.

### DIFF
--- a/libguinget/DownloadProgressForm.Designer.vb
+++ b/libguinget/DownloadProgressForm.Designer.vb
@@ -35,36 +35,40 @@ Partial Class DownloadProgressForm
         '
         Me.progressbarDownloadProgress.Anchor = CType(((System.Windows.Forms.AnchorStyles.Top Or System.Windows.Forms.AnchorStyles.Left) _
             Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)
-        Me.progressbarDownloadProgress.Location = New System.Drawing.Point(12, 29)
+        Me.progressbarDownloadProgress.Location = New System.Drawing.Point(10, 23)
+        Me.progressbarDownloadProgress.Margin = New System.Windows.Forms.Padding(2, 2, 2, 2)
         Me.progressbarDownloadProgress.MarqueeAnimationSpeed = 63
         Me.progressbarDownloadProgress.Name = "progressbarDownloadProgress"
-        Me.progressbarDownloadProgress.Size = New System.Drawing.Size(422, 23)
+        Me.progressbarDownloadProgress.Size = New System.Drawing.Size(338, 18)
         Me.progressbarDownloadProgress.TabIndex = 0
         '
         'labelDownloadingPackageList
         '
         Me.labelDownloadingPackageList.AutoSize = True
-        Me.labelDownloadingPackageList.Location = New System.Drawing.Point(9, 9)
+        Me.labelDownloadingPackageList.Location = New System.Drawing.Point(7, 7)
+        Me.labelDownloadingPackageList.Margin = New System.Windows.Forms.Padding(2, 0, 2, 0)
         Me.labelDownloadingPackageList.Name = "labelDownloadingPackageList"
-        Me.labelDownloadingPackageList.Size = New System.Drawing.Size(180, 17)
+        Me.labelDownloadingPackageList.Size = New System.Drawing.Size(138, 13)
         Me.labelDownloadingPackageList.TabIndex = 1
         Me.labelDownloadingPackageList.Text = "Downloading package list..."
         '
         'labelSourceName
         '
         Me.labelSourceName.AutoSize = True
-        Me.labelSourceName.Location = New System.Drawing.Point(-3, -3)
+        Me.labelSourceName.Location = New System.Drawing.Point(-2, -2)
+        Me.labelSourceName.Margin = New System.Windows.Forms.Padding(2, 0, 2, 0)
         Me.labelSourceName.Name = "labelSourceName"
-        Me.labelSourceName.Size = New System.Drawing.Size(100, 17)
+        Me.labelSourceName.Size = New System.Drawing.Size(76, 13)
         Me.labelSourceName.TabIndex = 2
         Me.labelSourceName.Text = "Source name: "
         '
         'labelSourceLocation
         '
         Me.labelSourceLocation.AutoSize = True
-        Me.labelSourceLocation.Location = New System.Drawing.Point(-3, 14)
+        Me.labelSourceLocation.Location = New System.Drawing.Point(-2, 11)
+        Me.labelSourceLocation.Margin = New System.Windows.Forms.Padding(2, 0, 2, 0)
         Me.labelSourceLocation.Name = "labelSourceLocation"
-        Me.labelSourceLocation.Size = New System.Drawing.Size(114, 17)
+        Me.labelSourceLocation.Size = New System.Drawing.Size(87, 13)
         Me.labelSourceLocation.TabIndex = 3
         Me.labelSourceLocation.Text = "Source location: "
         '
@@ -75,40 +79,42 @@ Partial Class DownloadProgressForm
         Me.panelSourceInfo.AutoScroll = True
         Me.panelSourceInfo.Controls.Add(Me.labelSourceLocation)
         Me.panelSourceInfo.Controls.Add(Me.labelSourceName)
-        Me.panelSourceInfo.Location = New System.Drawing.Point(12, 58)
+        Me.panelSourceInfo.Location = New System.Drawing.Point(10, 46)
+        Me.panelSourceInfo.Margin = New System.Windows.Forms.Padding(2, 2, 2, 2)
         Me.panelSourceInfo.Name = "panelSourceInfo"
-        Me.panelSourceInfo.Size = New System.Drawing.Size(422, 68)
+        Me.panelSourceInfo.Size = New System.Drawing.Size(338, 54)
         Me.panelSourceInfo.TabIndex = 4
         '
         'buttonCancel
         '
         Me.buttonCancel.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)
         Me.buttonCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel
-        Me.buttonCancel.Location = New System.Drawing.Point(339, 132)
+        Me.buttonCancel.Location = New System.Drawing.Point(271, 106)
+        Me.buttonCancel.Margin = New System.Windows.Forms.Padding(2, 2, 2, 2)
         Me.buttonCancel.Name = "buttonCancel"
-        Me.buttonCancel.Size = New System.Drawing.Size(95, 30)
+        Me.buttonCancel.Size = New System.Drawing.Size(76, 24)
         Me.buttonCancel.TabIndex = 5
         Me.buttonCancel.Text = "Cancel"
         Me.buttonCancel.UseVisualStyleBackColor = True
         '
         'DownloadProgressForm
         '
-        Me.AutoScaleDimensions = New System.Drawing.SizeF(120.0!, 120.0!)
+        Me.AutoScaleDimensions = New System.Drawing.SizeF(96.0!, 96.0!)
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi
         Me.CancelButton = Me.buttonCancel
-        Me.ClientSize = New System.Drawing.Size(447, 174)
+        Me.ClientSize = New System.Drawing.Size(358, 139)
         Me.Controls.Add(Me.buttonCancel)
         Me.Controls.Add(Me.panelSourceInfo)
         Me.Controls.Add(Me.labelDownloadingPackageList)
         Me.Controls.Add(Me.progressbarDownloadProgress)
         Me.FormBorderStyle = System.Windows.Forms.FormBorderStyle.SizableToolWindow
+        Me.Margin = New System.Windows.Forms.Padding(2, 2, 2, 2)
         Me.MaximizeBox = False
         Me.MinimizeBox = False
         Me.Name = "DownloadProgressForm"
         Me.ShowIcon = False
         Me.ShowInTaskbar = False
         Me.Text = "DownloadProgressForm"
-        Me.TopMost = True
         Me.panelSourceInfo.ResumeLayout(False)
         Me.panelSourceInfo.PerformLayout()
         Me.ResumeLayout(False)

--- a/libguinget/ExtraTools.vb
+++ b/libguinget/ExtraTools.vb
@@ -1,0 +1,34 @@
+﻿' libguinget - Package and package list tools for guinget
+'              and other programs that want to use them.
+' Copyright (C) 2020-2021 Drew Naylor
+' (Note that the copyright years include the years left out by the hyphen.)
+' winget, Windows, and all related words are copyright and trademark Microsoft Corporation.
+'
+' This file is a part of the guinget project.
+' Neither guinget nor Drew Naylor are associated with Microsoft
+' and Microsoft does not endorse guinget.
+'
+'
+'   Licensed under the Apache License, Version 2.0 (the "License");
+'   you may not use this file except in compliance with the License.
+'   You may obtain a copy of the License at
+'
+'     http://www.apache.org/licenses/LICENSE-2.0
+'
+'   Unless required by applicable law or agreed to in writing, software
+'   distributed under the License is distributed on an "AS IS" BASIS,
+'   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+'   See the License for the specific language governing permissions and
+'   limitations under the License.
+
+
+
+Public Class ExtraTools
+
+    ' Replacement MessageBox sub so that I don't have to do If/Else statements everywhere
+    ' and can instead reuse code.
+    Friend Shared Sub MessageBoxShowWithRootForm(RootForm As System.Windows.Forms.Form, MessageText As String, MessageCaption As String)
+
+    End Sub
+
+End Class

--- a/libguinget/PackageListTools.vb
+++ b/libguinget/PackageListTools.vb
@@ -59,7 +59,6 @@ Public Class PackageListTools
             ' of everything.
             RootFormTools.ProgressFormShow(RootForm, progressform)
 
-
             ' Define uri with source url.
             Dim PkgUri As Uri = New Uri(SourceUrl)
 
@@ -244,14 +243,7 @@ Public Class PackageListTools
 
                 ' Specify whether or not the form should stay on top
                 ' of everything.
-                If RootForm IsNot Nothing Then
-                    progressform.Show(RootForm)
-                    progressform.TopMost = False
-                Else
-                    ' Show progress form.
-                    progressform.Show()
-                    progressform.TopMost = True
-                End If
+                RootFormTools.ProgressFormShow(RootForm, progressform)
 
                 ' Start the progress bar.
                 progressform.progressbarDownloadProgress.Style = ProgressBarStyle.Marquee

--- a/libguinget/PackageListTools.vb
+++ b/libguinget/PackageListTools.vb
@@ -113,14 +113,14 @@ Public Class PackageListTools
                 ' Temporary, basic error handler in case we can't find
                 ' the source's URL. This may happen if there's
                 ' no Internet connection.
-                MessageBox.Show("Couldn't find " & SourceUrl & ". Please check your connection and try again. If you're online, the source may be unavailable.",
+                MessageBox.Show(progressform, "Couldn't find " & SourceUrl & ". Please check your connection and try again. If you're online, the source may be unavailable.",
                                 "Downloading manifests")
                 Exit Function
 
             Catch ex As IO.DirectoryNotFoundException
                 ' Catch directory not found exceptions if the user cancels the update early
                 ' after deleting the package list zip file downloaded during the previous update.
-                MessageBox.Show(ex.Message & vbCrLf &
+                MessageBox.Show(progressform, ex.Message & vbCrLf &
                                 vbCrLf &
                                 "This may be caused by having the directory above open in another program like Explorer. Please try again.",
                                 "Downloading manifests")
@@ -193,7 +193,7 @@ Public Class PackageListTools
                                    System.IO.Directory.Delete(tempDir, True)
                                    System.IO.Directory.CreateDirectory(tempDir)
                                Catch ex As System.IO.IOException
-                                   MessageBox.Show("A file in the requested directory is in use by another process. Please close it and try again.", "Deleting temp dir")
+                                   MessageBox.Show(RootForm, "A file in the requested directory is in use by another process. Please close it and try again.", "Deleting temp dir")
                                End Try
                            End Sub)
 
@@ -286,13 +286,13 @@ Public Class PackageListTools
                                                ZipFile.ExtractToDirectory(tempDir & "\winget-pkgs-master.zip", tempDir & "\winget-pkgs-master\")
                                            End If
                                        Catch ex As System.IO.FileNotFoundException
-                                           MessageBox.Show("Couldn't find " & tempDir & "\winget-pkgs-master.zip",
+                                           MessageBox.Show(progressform, "Couldn't find " & tempDir & "\winget-pkgs-master.zip",
                                            "Extracting manifests")
                                        Catch ex As System.IO.DirectoryNotFoundException
-                                           MessageBox.Show("Couldn't find " & tempDir & "\winget-pkgs-master",
+                                           MessageBox.Show(progressform, "Couldn't find " & tempDir & "\winget-pkgs-master",
                                            "Extracting manifests")
                                        Catch ex As System.IO.InvalidDataException
-                                           MessageBox.Show("We couldn't extract the manifest package. Please verify that the source URL is correct, and try again." & vbCrLf &
+                                           MessageBox.Show(progressform, "We couldn't extract the manifest package. Please verify that the source URL is correct, and try again." & vbCrLf &
                                            vbCrLf & "Details:" & vbCrLf &
                                            ex.GetType.ToString & ": " & ex.Message,
                                            "Extracting manifests")
@@ -305,13 +305,13 @@ Public Class PackageListTools
                                                    ZipFile.ExtractToDirectory(DatabaseTempDir & "\source.msix", DatabaseTempDir & "\source\")
                                                End If
                                            Catch ex As System.IO.FileNotFoundException
-                                               MessageBox.Show("Couldn't find " & DatabaseTempDir & "\source.msix",
+                                               MessageBox.Show(progressform, "Couldn't find " & DatabaseTempDir & "\source.msix",
                                            "Extracting manifests")
                                            Catch ex As System.IO.DirectoryNotFoundException
-                                               MessageBox.Show("Couldn't find " & DatabaseTempDir & "\source",
+                                               MessageBox.Show(progressform, "Couldn't find " & DatabaseTempDir & "\source",
                                            "Extracting manifests")
                                            Catch ex As System.IO.InvalidDataException
-                                               MessageBox.Show("We couldn't extract the database package. Please verify that the source URL is correct, and try again." & vbCrLf &
+                                               MessageBox.Show(progressform, "We couldn't extract the database package. Please verify that the source URL is correct, and try again." & vbCrLf &
                                            vbCrLf & "Details:" & vbCrLf &
                                            ex.GetType.ToString & ": " & ex.Message,
                                            "Extracting manifests")
@@ -405,11 +405,11 @@ Public Class PackageListTools
 
                                                My.Computer.FileSystem.CopyDirectory(tempDir & "\winget-pkgs-master\winget-pkgs-master\manifests", ManifestDir)
                                            Catch ex As System.IO.DirectoryNotFoundException
-                                               MessageBox.Show("Couldn't find " & tempDir & "\winget-pkgs-master\winget-pkgs-master\manifests" & vbCrLf &
-                                                               "Please close any Explorer windows that may be open in this directory, and try again.",
-                                               "Copying manifests")
+                                               Dim message As String = "Couldn't find " & tempDir & "\winget-pkgs-master\winget-pkgs-master\manifests" & vbCrLf &
+                                                               "Please close any Explorer windows that may be open in this directory, and try again."
+                                               MessageBox.Show(progressform, message, "Copying manifests")
                                            Catch ex As System.IO.IOException
-                                               MessageBox.Show("Please close any Explorer windows that may be open in this directory, and try again." & vbCrLf &
+                                               MessageBox.Show(progressform, "Please close any Explorer windows that may be open in this directory, and try again." & vbCrLf &
                                                                vbCrLf &
                                                                "Details:" & vbCrLf &
                                                                ex.Message, "Copying manifests")

--- a/libguinget/PackageListTools.vb
+++ b/libguinget/PackageListTools.vb
@@ -57,15 +57,7 @@ Public Class PackageListTools
 
             ' Specify whether or not the form should stay on top
             ' of everything.
-            If RootForm IsNot Nothing Then
-                progressform.Show(RootForm)
-                progressform.TopMost = False
-            Else
-                ' Show progress form.
-                progressform.Show()
-                progressform.TopMost = True
-            End If
-
+            RootFormTools.ProgressFormShow(RootForm, progressform)
 
 
             ' Define uri with source url.
@@ -113,14 +105,14 @@ Public Class PackageListTools
                 ' Temporary, basic error handler in case we can't find
                 ' the source's URL. This may happen if there's
                 ' no Internet connection.
-                MessageBox.Show(progressform, "Couldn't find " & SourceUrl & ". Please check your connection and try again. If you're online, the source may be unavailable.",
+                RootFormTools.MessageBoxShowWithRootForm(progressform, "Couldn't find " & SourceUrl & ". Please check your connection and try again. If you're online, the source may be unavailable.",
                                 "Downloading manifests")
                 Exit Function
 
             Catch ex As IO.DirectoryNotFoundException
                 ' Catch directory not found exceptions if the user cancels the update early
                 ' after deleting the package list zip file downloaded during the previous update.
-                MessageBox.Show(progressform, ex.Message & vbCrLf &
+                RootFormTools.MessageBoxShowWithRootForm(progressform, ex.Message & vbCrLf &
                                 vbCrLf &
                                 "This may be caused by having the directory above open in another program like Explorer. Please try again.",
                                 "Downloading manifests")
@@ -193,7 +185,7 @@ Public Class PackageListTools
                                    System.IO.Directory.Delete(tempDir, True)
                                    System.IO.Directory.CreateDirectory(tempDir)
                                Catch ex As System.IO.IOException
-                                   MessageBox.Show(RootForm, "A file in the requested directory is in use by another process. Please close it and try again.", "Deleting temp dir")
+                                   RootFormTools.MessageBoxShowWithRootForm(RootForm, "A file in the requested directory is in use by another process. Please close it and try again.", "Deleting temp dir")
                                End Try
                            End Sub)
 
@@ -325,11 +317,11 @@ Public Class PackageListTools
                                        End If
 
                                        Dim extraction7z As New Process
-                                           extraction7z.StartInfo.FileName = PathTo7zip
+                                       extraction7z.StartInfo.FileName = PathTo7zip
                                        extraction7z.StartInfo.Arguments = "x -bd " & tempDir & "\winget-pkgs-master.zip -o" & tempDir & "\winget-pkgs-master\"
                                        extraction7z.Start()
-                                           ' Wait for 7zip to exit, otherwise it'll move on too soon.
-                                           extraction7z.WaitForExit()
+                                       ' Wait for 7zip to exit, otherwise it'll move on too soon.
+                                       extraction7z.WaitForExit()
 
                                        If UpdateDatabase = True Then
                                            ' The calling app wants to use 7zip, so use it.
@@ -405,11 +397,11 @@ Public Class PackageListTools
 
                                                My.Computer.FileSystem.CopyDirectory(tempDir & "\winget-pkgs-master\winget-pkgs-master\manifests", ManifestDir)
                                            Catch ex As System.IO.DirectoryNotFoundException
-                                               Dim message As String = "Couldn't find " & tempDir & "\winget-pkgs-master\winget-pkgs-master\manifests" & vbCrLf &
-                                                               "Please close any Explorer windows that may be open in this directory, and try again."
-                                               MessageBox.Show(progressform, message, "Copying manifests")
+                                               RootFormTools.MessageBoxShowWithRootForm(progressform, "Couldn't find " & tempDir & "\winget-pkgs-master\winget-pkgs-master\manifests" & vbCrLf &
+                                                               "Please close any Explorer windows that may be open in this directory, and try again.",
+                                               "Copying manifests")
                                            Catch ex As System.IO.IOException
-                                               MessageBox.Show(progressform, "Please close any Explorer windows that may be open in this directory, and try again." & vbCrLf &
+                                               RootFormTools.MessageBoxShowWithRootForm(progressform, "Please close any Explorer windows that may be open in this directory, and try again." & vbCrLf &
                                                                vbCrLf &
                                                                "Details:" & vbCrLf &
                                                                ex.Message, "Copying manifests")

--- a/libguinget/PackageListTools.vb
+++ b/libguinget/PackageListTools.vb
@@ -104,14 +104,14 @@ Public Class PackageListTools
                 ' Temporary, basic error handler in case we can't find
                 ' the source's URL. This may happen if there's
                 ' no Internet connection.
-                RootFormTools.MessageBoxShowWithRootForm(progressform, "Couldn't find " & SourceUrl & ". Please check your connection and try again. If you're online, the source may be unavailable.",
+                MessageBox.Show("Couldn't find " & SourceUrl & ". Please check your connection and try again. If you're online, the source may be unavailable.",
                                 "Downloading manifests")
                 Exit Function
 
             Catch ex As IO.DirectoryNotFoundException
                 ' Catch directory not found exceptions if the user cancels the update early
                 ' after deleting the package list zip file downloaded during the previous update.
-                RootFormTools.MessageBoxShowWithRootForm(progressform, ex.Message & vbCrLf &
+                MessageBox.Show(ex.Message & vbCrLf &
                                 vbCrLf &
                                 "This may be caused by having the directory above open in another program like Explorer. Please try again.",
                                 "Downloading manifests")
@@ -184,7 +184,7 @@ Public Class PackageListTools
                                    System.IO.Directory.Delete(tempDir, True)
                                    System.IO.Directory.CreateDirectory(tempDir)
                                Catch ex As System.IO.IOException
-                                   RootFormTools.MessageBoxShowWithRootForm(RootForm, "A file in the requested directory is in use by another process. Please close it and try again.", "Deleting temp dir")
+                                   MessageBox.Show("A file in the requested directory is in use by another process. Please close it and try again.", "Deleting temp dir")
                                End Try
                            End Sub)
 
@@ -270,13 +270,13 @@ Public Class PackageListTools
                                                ZipFile.ExtractToDirectory(tempDir & "\winget-pkgs-master.zip", tempDir & "\winget-pkgs-master\")
                                            End If
                                        Catch ex As System.IO.FileNotFoundException
-                                           MessageBox.Show(progressform, "Couldn't find " & tempDir & "\winget-pkgs-master.zip",
+                                           MessageBox.Show("Couldn't find " & tempDir & "\winget-pkgs-master.zip",
                                            "Extracting manifests")
                                        Catch ex As System.IO.DirectoryNotFoundException
-                                           MessageBox.Show(progressform, "Couldn't find " & tempDir & "\winget-pkgs-master",
+                                           MessageBox.Show("Couldn't find " & tempDir & "\winget-pkgs-master",
                                            "Extracting manifests")
                                        Catch ex As System.IO.InvalidDataException
-                                           MessageBox.Show(progressform, "We couldn't extract the manifest package. Please verify that the source URL is correct, and try again." & vbCrLf &
+                                           MessageBox.Show("We couldn't extract the manifest package. Please verify that the source URL is correct, and try again." & vbCrLf &
                                            vbCrLf & "Details:" & vbCrLf &
                                            ex.GetType.ToString & ": " & ex.Message,
                                            "Extracting manifests")
@@ -289,13 +289,13 @@ Public Class PackageListTools
                                                    ZipFile.ExtractToDirectory(DatabaseTempDir & "\source.msix", DatabaseTempDir & "\source\")
                                                End If
                                            Catch ex As System.IO.FileNotFoundException
-                                               MessageBox.Show(progressform, "Couldn't find " & DatabaseTempDir & "\source.msix",
+                                               MessageBox.Show("Couldn't find " & DatabaseTempDir & "\source.msix",
                                            "Extracting manifests")
                                            Catch ex As System.IO.DirectoryNotFoundException
-                                               MessageBox.Show(progressform, "Couldn't find " & DatabaseTempDir & "\source",
+                                               MessageBox.Show("Couldn't find " & DatabaseTempDir & "\source",
                                            "Extracting manifests")
                                            Catch ex As System.IO.InvalidDataException
-                                               MessageBox.Show(progressform, "We couldn't extract the database package. Please verify that the source URL is correct, and try again." & vbCrLf &
+                                               MessageBox.Show("We couldn't extract the database package. Please verify that the source URL is correct, and try again." & vbCrLf &
                                            vbCrLf & "Details:" & vbCrLf &
                                            ex.GetType.ToString & ": " & ex.Message,
                                            "Extracting manifests")
@@ -389,11 +389,11 @@ Public Class PackageListTools
 
                                                My.Computer.FileSystem.CopyDirectory(tempDir & "\winget-pkgs-master\winget-pkgs-master\manifests", ManifestDir)
                                            Catch ex As System.IO.DirectoryNotFoundException
-                                               RootFormTools.MessageBoxShowWithRootForm(progressform, "Couldn't find " & tempDir & "\winget-pkgs-master\winget-pkgs-master\manifests" & vbCrLf &
+                                               MessageBox.Show("Couldn't find " & tempDir & "\winget-pkgs-master\winget-pkgs-master\manifests" & vbCrLf &
                                                                "Please close any Explorer windows that may be open in this directory, and try again.",
                                                "Copying manifests")
                                            Catch ex As System.IO.IOException
-                                               RootFormTools.MessageBoxShowWithRootForm(progressform, "Please close any Explorer windows that may be open in this directory, and try again." & vbCrLf &
+                                               MessageBox.Show("Please close any Explorer windows that may be open in this directory, and try again." & vbCrLf &
                                                                vbCrLf &
                                                                "Details:" & vbCrLf &
                                                                ex.Message, "Copying manifests")

--- a/libguinget/PackageListTools.vb
+++ b/libguinget/PackageListTools.vb
@@ -50,7 +50,7 @@ Public Class PackageListTools
         ' https://stackoverflow.com/a/54475013
 
         ' Show a progress form that says what's being done.
-        Using progressform As New libguinget.DownloadProgressForm
+        Using progressform As New DownloadProgressForm
             ' Set progress form properties.
             progressform.PackageListUrl = SourceUrl
             progressform.PackageListSourceName = SourceName
@@ -349,14 +349,7 @@ Public Class PackageListTools
 
                     ' Specify whether or not the form should stay on top
                     ' of everything.
-                    If RootForm IsNot Nothing Then
-                        progressform.Show(RootForm)
-                        progressform.TopMost = False
-                    Else
-                        ' Show progress form.
-                        progressform.Show()
-                        progressform.TopMost = True
-                    End If
+                    RootFormTools.ProgressFormShow(RootForm, progressform)
 
                     ' Start the progress bar.
                     progressform.progressbarDownloadProgress.Style = ProgressBarStyle.Marquee

--- a/libguinget/RootFormTools.vb
+++ b/libguinget/RootFormTools.vb
@@ -22,13 +22,36 @@
 '   limitations under the License.
 
 
+Imports System.Windows.Forms
 
-Public Class ExtraTools
+Public Class RootFormTools
 
     ' Replacement MessageBox sub so that I don't have to do If/Else statements everywhere
     ' and can instead reuse code.
-    Friend Shared Sub MessageBoxShowWithRootForm(RootForm As System.Windows.Forms.Form, MessageText As String, MessageCaption As String)
+    Friend Shared Sub MessageBoxShowWithRootForm(RootForm As Form, MessageText As String, MessageCaption As String)
 
+        ' Check if the root form is Nothing.
+        If RootForm Is Nothing Then
+            ' If it is, just do the regular message.
+            MessageBox.Show(MessageText, MessageCaption)
+        Else
+            ' Otherwise, use the root form.
+            MessageBox.Show(RootForm, MessageText, MessageCaption)
+        End If
+    End Sub
+
+    Friend Shared Sub ProgressFormShow(RootForm As Form, ProgressForm As Form)
+        ' Specify whether or not the form should stay on top
+        ' of everything.
+        ' Moved here from the code so it can be modified in one place.
+        If RootForm IsNot Nothing Then
+            ProgressForm.Show(RootForm)
+            ProgressForm.TopMost = False
+        Else
+            ' Show progress form.
+            ProgressForm.Show()
+            ProgressForm.TopMost = True
+        End If
     End Sub
 
 End Class

--- a/libguinget/RootFormTools.vb
+++ b/libguinget/RootFormTools.vb
@@ -31,12 +31,12 @@ Public Class RootFormTools
     Friend Shared Sub MessageBoxShowWithRootForm(RootForm As Form, MessageText As String, MessageCaption As String)
 
         ' Check if the root form is Nothing.
-        If RootForm Is Nothing Then
-            ' If it is, just do the regular message.
-            MessageBox.Show(MessageText, MessageCaption)
-        Else
-            ' Otherwise, use the root form.
+        If RootForm IsNot Nothing Then
+            ' Use the root form.
             MessageBox.Show(RootForm, MessageText, MessageCaption)
+        Else
+            ' Otherwise, just do the regular message.
+            MessageBox.Show(MessageText, MessageCaption)
         End If
     End Sub
 

--- a/libguinget/RootFormTools.vb
+++ b/libguinget/RootFormTools.vb
@@ -26,20 +26,6 @@ Imports System.Windows.Forms
 
 Public Class RootFormTools
 
-    ' Replacement MessageBox sub so that I don't have to do If/Else statements everywhere
-    ' and can instead reuse code.
-    Friend Shared Sub MessageBoxShowWithRootForm(RootForm As Form, MessageText As String, MessageCaption As String)
-
-        ' Check if the root form is Nothing.
-        If RootForm IsNot Nothing Then
-            ' Use the root form.
-            MessageBox.Show(RootForm, MessageText, MessageCaption)
-        Else
-            ' Otherwise, just do the regular message.
-            MessageBox.Show(MessageText, MessageCaption)
-        End If
-    End Sub
-
     Friend Shared Sub ProgressFormShow(RootForm As Form, ProgressForm As Form)
         ' Specify whether or not the form should stay on top
         ' of everything.

--- a/libguinget/libguinget.vbproj
+++ b/libguinget/libguinget.vbproj
@@ -112,7 +112,7 @@
       <SubType>Form</SubType>
     </Compile>
     <Compile Include="CommandTools.vb" />
-    <Compile Include="ExtraTools.vb" />
+    <Compile Include="RootFormTools.vb" />
     <Compile Include="PackageListTools.vb" />
     <Compile Include="PackageTools.vb" />
     <Compile Include="My Project\AssemblyInfo.vb" />

--- a/libguinget/libguinget.vbproj
+++ b/libguinget/libguinget.vbproj
@@ -112,6 +112,7 @@
       <SubType>Form</SubType>
     </Compile>
     <Compile Include="CommandTools.vb" />
+    <Compile Include="ExtraTools.vb" />
     <Compile Include="PackageListTools.vb" />
     <Compile Include="PackageTools.vb" />
     <Compile Include="My Project\AssemblyInfo.vb" />


### PR DESCRIPTION
Moved the stuff to determine whether the progress dialog should be on top of a root form or just on top of everything to its own class to make editing easier. Also made the progress dialog not on top by default so it doesn't make the window show back up every time it goes to a different phase.