### PR TITLE
Add v0.2 usage guide.

### DIFF
--- a/docs/How-to-use.md
+++ b/docs/How-to-use.md
@@ -8,7 +8,9 @@ This guide is up-to-date as of version 0.2. You can get here at any time from `H
 
 ## Running guinget as administrator
 
-Please don't run guinget as administrator in version 0.1.3 or higher, as winget seems to have an issue updating its sources when running elevated (which is what guinget does if guinget itself is elevated). If you need to install a package with winget elevated, please use the `Elevate winget (UAC)` checkbox in the `Apply changes` window as described in the `Installation options` section below. Be sure to use the `Update winget sources` menu item described in the `Updating winget sources` section below if winget complains that it can't find that package/package version, then try installing that package again.
+Please don't run guinget as administrator in version 0.1.3 or higher, as winget seems to have an issue updating its sources when running elevated from an account that's not marked as `Administrator` in the `Settings` app (which is what guinget does if guinget itself is elevated). If you need to install a package with winget elevated (this sometimes seems to be necessary even if your account is an `Administrator`), please use the `Elevate winget with UAC` checkbox in the `Options: Apply Changes` window accessible from the `Options...` link label in the bottom-left corner of the `Apply changes` window as described in the `Installation options` section below. Be sure to use the `Update winget sources` menu item described in the `Updating winget sources` section below if winget complains that it can't find that package/package version, then try installing that package again.
+
+Sometimes winget won't let you run it elevated from a non-`Administrator` account, so you'll just have to either give yourself temporary permissions to install certain packages that require elevation, or log into your `Administrator` account for those packages. Most people don't run Windows like this, but it's safer.
 
 Hopefully someday this won't be a problem, but it will be until then.
 

--- a/docs/How-to-use.md
+++ b/docs/How-to-use.md
@@ -218,6 +218,8 @@ Eventually this tab will be moved to a sources manager app. If a particular fold
 
 In case there's something you need to drop into a terminal for, you can do it with `File>Run CMD`. There's also a way to run it elevated using `File>Run CMD elevated (UAC)`. There are keyboard shortcuts for both, the non-elevated one being `Ctrl+Alt+T` and the elevated one being `Ctrl+Alt+Shift+T`.
 
+Please be aware that [running CMD from guinget on 64-bit Windows causes filesystem redirection to occur, resulting in anything that has to be launched from the "real" System32 not working correctly](https://github.com/DrewNaylor/guinget/issues/98). This shouldn't impact most people, but it will if you need to run something like SystemPropertiesProtection.exe. The only workaround I can offer is to just run CMD from the Start menu or something else instead. I could tell Windows to run CMD from SysNative, but that doesn't work when running it elevated since it just crashes. A real solution would be to compile a 64-bit version of guinget, but winget doesn't offer separate architectures yet and I don't want people to have to manually install a different version.
+
 ## Switch tabs with mouse scroll wheel
 
 You can switch tab control tabs like the ones in the `Options` window using the mouse scroll wheel, just like in many Linux applications. This is provided by [libscrollswitchtabs](https://drew-naylor.com/drews-libs/libscrollswitchtabs-how-to-use.html).

--- a/docs/How-to-use.md
+++ b/docs/How-to-use.md
@@ -51,11 +51,7 @@ Please note this isn't available if more than one package is selected at once.
 ## Marking a package
 
 Marking a package involves doing one of the following actions:
-- Double-click or right-click on a selected package and click one of these items:
-  - `Action: Install`
-  - `Action: Uninstall`
-  - `Action: Upgrade`
-- Open the `Selected packages` menu and click one of these:
+- Open the `Selected packages` menu or Double-click or right-click on a selected package and click one of these:
   - `Action: Install`
   - `Action: Uninstall`
   - `Action: Upgrade` (unfortunately there's no better character to have the accelerator on for "upgrade" than the letter "p" as far as I know)
@@ -63,7 +59,10 @@ Marking a package involves doing one of the following actions:
   - `Ctrl+I` for install (capital "i", in case it looks similar to a lowercase "L")
   - `Ctrl+U` for uninstall
   - `Ctrl+P` for upgrade
-- Open the combobox dropdown menu for the selected package in the `Action` column and use one of the items in the list (may take a few clicks to open the dropdown)
+- Open the combobox dropdown menu for the selected package in the `Action` column (may take a few clicks to open the dropdown) and use one of these items in the list:
+  - `Install`
+  - `Uninstall`
+  - `Upgrade`
 - Move the cell selection over to the `Action` column with the arrow keys then press `spacebar`, then use the arrow keys to select `Install`, `Uninstall`, or `Upgrade`. Pressing `Enter` will move to the next package row.
 
 This also applies to marking a package for uninstallation (once that's available), or for marking a package as one you want to ignore (ignoring is `Do nothing`).

--- a/docs/How-to-use.md
+++ b/docs/How-to-use.md
@@ -89,7 +89,9 @@ Marked changes are applied using the `Apply changes` dialog, accessible through 
 
 Using the `Confirm changes` button will bulk-apply all listed changes. Alternatively, you can apply one change at a time by double-clicking or pressing `Enter` on each package in the list to install, uninstall, or upgrade it when ready.
 
-If you have issues with winget while applying changes, you can close and reopen the `Apply changes` window to reset the controls and packages to the `Ready` state to try again, perhaps with different options as described below.
+If you have issues with winget while applying changes, you can reset the status of some or all the packages by right-clicking on the list and selecting either `Reset status for selected package` or `Reset status for all packages` to reset the controls and packages to the `Ready` state to try again, perhaps with different options as described below.
+
+In case there's a package you forgot was marked or had its status reset and you don't want to apply changes to that package again without unmarking it or installing packages individually, you can right-click on it and choose `Skip selected package`. Any package with the `Current status` of `Skip` will be ignored until the `Apply changes` window is re-opened or the status for that package is reset.
 
 ### Installation options
 

--- a/docs/How-to-use.md
+++ b/docs/How-to-use.md
@@ -116,7 +116,7 @@ There are also two buttons at the bottom of the mini-form: `Defaults` and `Close
 
 These will persist across closing the `Apply changes` window and restarting or upgrading guinget.
 
-## Searching for packages
+## Searching and filtering for packages
 
 You can search for packages using the search bar in the toolbar at the top of the window. This only filters the `Package` column for now, but other columns are planned to be supported. To start a search, do one of the following:
 - Click in the search textbox
@@ -130,14 +130,22 @@ You can use `Esc`/`Escape` and press `Enter` or, as described below, double-clic
 `Search for package ID` in either the package context menu or in the `Selected packages` menu will, as the name implies, search for the package ID as long as only one package is selected. This won't be available if more than one package is selected at a time in version 0.1.3 and above.
 
 ### Sidebar
-By default, there's a sidebar that shows your search terms from the current session, but you can hide it in a few ways:
+By default, there's a sidebar that shows your search terms from the current session and other filters, but you can hide it in a few ways:
 - With the `X` button in its top-right corner
 - Using `View>Sidebar`
 - By unchecking the `Show sidebar` checkbox from `Tools>Options...>Layout`
 
-Double-clicking/pressing `Enter` on the `All` entry at the top of the sidebar search terms list returns you to an unfiltered list.
+You can double-click or press `Enter` on any of the items in the various sidebar lists to filter/search based on which list is being shown in the dropdown at the top.
+
+Double-clicking/pressing `Enter` on the `All` entry at the top of the sidebar search terms list/filters lists returns you to an unfiltered list.
+
+###Sidebar: `Search terms` list
 
 You can clear all search terms or only selected search terms from the search terms list using the context menu. Please note that the `All` entry at the top will always be there and trying to remove it by clearing all search terms will put it back.
+
+### Sidebar: `Action` filters
+
+This list has filters that correspond to the `Action` column to make it easier to change how packages are marked or to simply view them, kinda like Synaptic.
 
 ### Search options
 

--- a/docs/How-to-use.md
+++ b/docs/How-to-use.md
@@ -50,7 +50,7 @@ After it's finished, the window will stay open and you can close it. Currently i
 
 In addition to a few details in the package list, full package details are displayed in the textbox below the package list. By default, the last package selected will have its details shown, but you can change it so only the first package selected (when using multi-select) has its details shown by unchecking `Show last-selected package details when selecting multiple packages` in `Tools>Options...>Package Details`.
 
-Please be aware that showing the last-selected package details might not work properly if you [use `Shift+Click` and the selection switches to go above the first-selected package as that makes it show the first-clicked package's details.](https://github.com/DrewNaylor/guinget/issues/42#issuecomment-716090028)
+Please be aware that showing the last-selected package details might not work properly if you [use `Shift+Click` and the selection switches to go above the first-selected package as that makes it show the first-clicked package's details.](https://github.com/DrewNaylor/guinget/issues/99)
 
 ### Show in winget
 

--- a/docs/How-to-use.md
+++ b/docs/How-to-use.md
@@ -39,6 +39,16 @@ Some options are available to modify the behavior when refreshing the cache. The
   - `Load only the latest version of each package` checkbox
     - Some packages may display a version number that's not really the latest version. Not sure how to fix this at the moment.
 	- Requires loading from the community database checkbox to be checked.
+	
+#### Notes on loading from the database
+
+- The package list will be loaded using the same SQLite database as winget uses by default, located at https://winget.azureedge.net/cache/source.msix. As briefly mentioned above, this still relies on the manifests to get the package details as those aren't directly available in the database.
+- Each package version is listed as a separate entry even when loading from the database, though using the database will make sure only packages winget can display right now are shown.
+- Some packages may be in a different order compared to loading all the manifests at once, but this shouldn't be much of an issue, and clicking the Package column header should sort them as expected.
+- Loading the details may still take a bit as we have to take the package ID and version number and figure out where its manifest is, instead of just grabbing all the manifests and loading from them. In case we can't find a package's manifest, we'll just look through all the manifests until we find the right one. Figuring out where each package's manifest is stored is done in three ways:
+  - If replacing all instances of "." in the package ID and appending the package version to the end of the path along with ".yaml" finds a file that exists, then that's great and we'll use that file. This is the fastest method.
+  - If that doesn't work, then we only replace the first instance of the "." in the ID and try again with the version thing. This should be fast, too.
+  - If neither of those work, then we fall back to looking for manifests with the package's version number in their filename, opening each file match we find, checking the package ID in the file, and if it's a match, we use it. Otherwise we keep going until we find the manifest. The Visual Studio profiler says there's a lot of garbage collection going on, so this will probably need to be changed to something like Using to keep automatic garbage collection to a minimum.
 
 ### Updating winget sources
 
@@ -193,7 +203,7 @@ The available options are as follows:
 - `Use exact match for selected package ID search` checkbox
   - By default, using the selected package ID search feature will do an exact match, but you can turn that off if you want.
 - `Search when typing` checkbox
-  - Searches are performed after a configurable wait time with no typing that defaults to 325 milliseconds. You can change the wait time with the number box below the `Search when typing` checkbox.
+  - Searches are performed after a configurable wait time with no typing that defaults to 325 milliseconds. You can change the wait time with the number box below the `Search when typing` checkbox. Minimum value for wait time is `1`, and maximum value is `9999`.
 
 ## Edit winget settings
 

--- a/docs/How-to-use.md
+++ b/docs/How-to-use.md
@@ -10,9 +10,11 @@ This guide is up-to-date as of version 0.2. You can get here at any time from `H
 
 Please don't run guinget as administrator in version 0.1.3 or higher, as winget seems to have an issue updating its sources when running elevated from an account that's not marked as `Administrator` in the `Settings` app (which is what guinget does if guinget itself is elevated). If you need to install a package with winget elevated (this sometimes seems to be necessary even if your account is an `Administrator`), please use the `Elevate winget with UAC` checkbox in the `Options: Apply Changes` window accessible from the `Options...` link label in the bottom-left corner of the `Apply changes` window as described in the `Installation options` section below. Be sure to use the `Update winget sources` menu item described in the `Updating winget sources` section below if winget complains that it can't find that package/package version, then try installing that package again.
 
-Sometimes winget won't let you run it elevated from a non-`Administrator` account, so you'll just have to either give yourself temporary permissions to install certain packages that require elevation, or log into your `Administrator` account for those packages. Most people don't run Windows like this, but it's safer.
+Sometimes winget won't let you run it elevated from a non-`Administrator` account, so you'll just have to either give yourself temporary permissions to install certain packages that require elevation, or log into your `Administrator` account for those packages. Most people don't run Windows like this, but it's safer. The issue with winget not allowing you to elevate like this seems to be a general issue with Store apps, as I tested this with the Windows Terminal and ran into the same problem.
 
-Hopefully someday this won't be a problem, but it will be until then.
+If you do want to run winget elevated, you'll have to first install it in your `Administrator` account, then install it in your regular user account if it's not already installed. This shouldn't be required once it's included with Windows.
+
+Hopefully someday requiring winget to be run elevated won't be a problem, but it will be until then.
 
 ## Refreshing package cache
 

--- a/docs/How-to-use.md
+++ b/docs/How-to-use.md
@@ -147,7 +147,7 @@ Please note that the `winget list` option requires the `list` experimental featu
 
 ## Importing and exporting packages
 
-You can import and export the list of packages from the respective menu items under `File` if `import` and/or `export` are available in winget and set to on if they're not default features.
+You can import and export the list of packages from the respective menu items under `File` if `import` and/or `export` are available in winget and set to on if they're not default features. `Ctrl+O` and `Ctrl+S` are also available as keyboard shortcuts for import and export, respectively.
 
 ## Searching and filtering for packages
 

--- a/docs/How-to-use.md
+++ b/docs/How-to-use.md
@@ -139,7 +139,7 @@ If `list` and `upgrade` are available in winget and they're set to on, you can u
 
 By default, `View>Installed packages...` opens the `Apps & features` Settings app page if possible, or the Control Panel's `Programs and Features` page if it's not. You can change this to a few different things using `Tools>Options...>Apps and UIs`. The available choices in the `Installed packages` dropdown are as follows:
 
-- `Settings app: Apps & features (default)
+- `Settings app: Apps & features (default)`
 - `CMD: winget list`
 - `Control Panel: Programs and Features`
 

--- a/docs/How-to-use.md
+++ b/docs/How-to-use.md
@@ -139,7 +139,7 @@ You can double-click or press `Enter` on any of the items in the various sidebar
 
 Double-clicking/pressing `Enter` on the `All` entry at the top of the sidebar search terms list/filters lists returns you to an unfiltered list.
 
-###Sidebar: `Search terms` list
+### Sidebar: `Search terms` list
 
 You can clear all search terms or only selected search terms from the search terms list using the context menu. Please note that the `All` entry at the top will always be there and trying to remove it by clearing all search terms will put it back.
 

--- a/docs/How-to-use.md
+++ b/docs/How-to-use.md
@@ -145,6 +145,10 @@ By default, `View>Installed packages...` opens the `Apps & features` Settings ap
 
 Please note that the `winget list` option requires the `list` experimental feature to be set to on in winget's config file if it's not already a default feature.
 
+## Importing and exporting packages
+
+You can import and export the list of packages from the respective menu items under `File` if `import` and/or `export` are available in winget and set to on if they're not default features.
+
 ## Searching and filtering for packages
 
 You can search for packages using the search bar in the toolbar at the top of the window. This only filters the `Package` column for now, but other columns are planned to be supported. To start a search, do one of the following:

--- a/docs/How-to-use.md
+++ b/docs/How-to-use.md
@@ -96,10 +96,10 @@ In case there's a package you forgot was marked or had its status reset and you 
 ### Installation options
 
 The following installation options are available:
-- Interactive installation: check the `Interactive install (-i)` checkbox to have winget give you an interactive installer instead of an automated one.
-- Elevated winget: check the `Elevate winget (UAC)` checkbox to run winget as an administrator. This may help for some packages that complain about not having permissions when installing them. 
+- Running interactively: Check the `Run interactively (winget -i)` checkbox to have winget give you an interactive installer instead of an automated one. Even though this is usually used for installers, it should also work for uninstallers. Upgrades should work ok, too.
+- Elevated winget: check the `Elevate winget with UAC` checkbox to run winget as an administrator. This may help for some packages that complain about not having permissions when installing them. 
   - Typically it's used in case you usually run Windows from a standard/limited user account and have an administrator account for system modification and application installation. 
-  - Please note that Windows 10 version 2004 might not be compatible with this option as it sometimes elevates package installers when necessary and says it can't run winget if it's started from an elevated CMD.
+  - Please note that some installations of Windows might not be compatible with this option as it sometimes elevates package installers when necessary and says it can't run winget if it's started from an elevated CMD.
   - Since this is one of the only reasons winget would need to be run elevated, **it's not recommended to run guinget as administrator as of version 0.1.3**.
 
 These will persist across closing the `Apply changes` window and restarting or upgrading guinget.

--- a/docs/How-to-use.md
+++ b/docs/How-to-use.md
@@ -27,6 +27,19 @@ Once you've started the update, just wait for it to complete, and try again if t
 
 Loading the package list and details will take a bit and may lock up slightly on slower systems, such as virtual machines. Additionally, please be aware that the main window cannot be moved while loading the package list and details, though this is something I want to allow.
 
+### Refresh cache options
+
+Some options are available to modify the behavior when refreshing the cache. They're listed below and accessible from `Tools>Options...>Refresh Cache`.
+
+- `Delete temporary files after cache update` checkbox
+  - Temporary files are always deleted before refreshing the cache.
+- `Update and load package list from winget's default community database` checkbox
+  - This will ensure guinget only displays packages winget's default source knows about and may be faster in some cases.
+  - Details will still be loaded from manifests.
+  - `Load only the latest version of each package` checkbox
+    - Some packages may display a version number that's not really the latest version. Not sure how to fix this at the moment.
+	- Requires loading from the community database checkbox to be checked.
+
 ### Updating winget sources
 
 Sometimes winget's sources will be out of date when you try to install something (even though it should automatically update before installation). If that's the case, you can update winget's sources without dropping into CMD using `Package list>Update winget sources`. This will run `winget source update`.

--- a/docs/How-to-use.md
+++ b/docs/How-to-use.md
@@ -99,7 +99,7 @@ The following installation options are available:
 - Running interactively: Check the `Run interactively (winget -i)` checkbox to have winget give you an interactive installer instead of an automated one. Even though this is usually used for installers, it should also work for uninstallers. Upgrades should work ok, too.
 - Elevated winget: check the `Elevate winget with UAC` checkbox to run winget as an administrator. This may help for some packages that complain about not having permissions when installing them. 
   - Typically it's used in case you usually run Windows from a standard/limited user account and have an administrator account for system modification and application installation. 
-  - Please note that some installations of Windows might not be compatible with this option as it sometimes elevates package installers when necessary and says it can't run winget if it's started from an elevated CMD.
+  - Please note that some installations of Windows might not be compatible with this option as it sometimes says it can't run winget if it's started from an elevated CMD. The issue seems to be that it can have trouble running APPX/MSIX packages elevated.
   - Since this is one of the only reasons winget would need to be run elevated, **it's not recommended to run guinget as administrator as of version 0.1.3**.
 
 These will persist across closing the `Apply changes` window and restarting or upgrading guinget.

--- a/docs/How-to-use.md
+++ b/docs/How-to-use.md
@@ -214,6 +214,10 @@ Some maintenance-related buttons are available under `Tools>Options...>Maintenan
   
 Eventually this tab will be moved to a sources manager app. If a particular folder doesn't exist, the button to delete it won't be available.
 
+## Running CMD
+
+In case there's something you need to drop into a terminal for, you can do it with `File>Run CMD`. There's also a way to run it elevated using `File>Run CMD elevated (UAC)`. There are keyboard shortcuts for both, the non-elevated one being `Ctrl+Alt+T` and the elevated one being `Ctrl+Alt+Shift+T`.
+
 ## Switch tabs with mouse scroll wheel
 
 You can switch tab control tabs like the ones in the `Options` window using the mouse scroll wheel, just like in many Linux applications. This is provided by [libscrollswitchtabs](https://drew-naylor.com/drews-libs/libscrollswitchtabs-how-to-use.html).

--- a/docs/How-to-use.md
+++ b/docs/How-to-use.md
@@ -72,11 +72,11 @@ Using the arrow keys to move the cell selection may not work sometimes, as I had
 ### Marking multiple packages
 
 To mark multiple packages, use these instructions:
-1. First, select them with the mouse (using `Shift` and `Ctrl` like you would for a list of files) or select them using `Shift` and the arrow keys.
+1. First, select them with the mouse (using `Shift` and `Ctrl` like you would for a list of files) or select them using `Shift` and the arrow keys. You might be able to use `Ctrl` and `spacebar` with the arrow keys, but that's untested.
 2. After selecting the packages you want to mark, do one of the following to mark them as you wish:
   - Right-click on one of the selected packages and use `Action: (action)` menu items
-  - Use the `Selected package>Action: (action)` menu items
-  - Press `Ctrl+I` to mark them all for install or `Ctrl+D` to unmark/ignore them
+  - Use the `Selected packages>Action: (action)` menu items
+  - Press keyboard shortcuts to mark them as desired
   
 Please refer to the `Marking a package` section for more details.
 
@@ -87,7 +87,7 @@ Marked changes are applied using the `Apply changes` dialog, accessible through 
 - `Package list>Apply changes...`
 - Pressing `Ctrl+H` 
 
-Using the `Confirm changes` button will bulk-apply all listed changes. Alternatively, you can apply one change at a time by double-clicking or pressing `Enter` on each package in the list to install (or uninstall, when that's available) it when ready.
+Using the `Confirm changes` button will bulk-apply all listed changes. Alternatively, you can apply one change at a time by double-clicking or pressing `Enter` on each package in the list to install, uninstall, or upgrade it when ready.
 
 If you have issues with winget while applying changes, you can close and reopen the `Apply changes` window to reset the controls and packages to the `Ready` state to try again, perhaps with different options as described below.
 

--- a/docs/How-to-use.md
+++ b/docs/How-to-use.md
@@ -82,6 +82,8 @@ This also applies to marking a package as one you want to ignore (ignoring is `D
 
 Using the arrow keys to move the cell selection may not work sometimes, as I had some issue getting it to work during testing.
 
+Please be aware that using `Uninstall` and `Upgrade` may require the corresponding experimental features to be on in winget if they're not already available by default.
+
 ### Marking multiple packages
 
 To mark multiple packages, use these instructions:
@@ -128,6 +130,20 @@ The following `Apply changes` options are available:
 There are also two buttons at the bottom of the mini-form: `Defaults` and `Close`. `Close` just closes the window and `Defaults` sets all the checkboxes back to default. Please be aware that the settings are automatically saved after resetting the checkboxes, as this window is intended to have the option to leave it open when applying changes and stuff, unlike the regular `Options` window.
 
 These will persist across closing the `Apply changes` window and restarting or upgrading guinget.
+
+## Showing available upgrades
+
+If `list` and `upgrade` are available in winget and they're set to on, you can use `View>Available upgrades...` to run `winget upgrade` and display packages that can be updated. For the moment, Store apps aren't supported in guinget, so you'll have to upgrade those manually through a command line or the Store itself.
+
+## Showing installed packages
+
+By default, `View>Installed packages...` opens the `Apps & features` Settings app page if possible, or the Control Panel's `Programs and Features` page if it's not. You can change this to a few different things using `Tools>Options...>Apps and UIs`. The available choices in the `Installed packages` dropdown are as follows:
+
+- `Settings app: Apps & features (default)
+- `CMD: winget list`
+- `Control Panel: Programs and Features`
+
+Please note that the `winget list` option requires the `list` experimental feature to be set to on in winget's config file if it's not already a default feature.
 
 ## Searching and filtering for packages
 

--- a/docs/How-to-use.md
+++ b/docs/How-to-use.md
@@ -168,7 +168,7 @@ You can edit winget's settings using `Tools>Edit winget settings`. If you wish t
 
 ## Resetting guinget's options to default
 
-If something breaks, you can use the `Defaults` button in the bottom-left corner of the `Options` window to reset everything, then click `OK` to save the default values. Some options like the one to hide unfinished controls and experimental stuff requires guinget to be restarted to take effect. Please be aware that if the guinget cache is what's broken, you'll have to manually delete it from `%AppData%\winget-frontends\source` for now. However, if winget's cache is broken, that may require resetting its sources from a command-line since there's no option for that in guinget yet.
+If something breaks, you can use the `Defaults` button in the bottom-left corner of the `Options` window to reset everything, then click `OK` to save the default values. Some options like the one to hide unfinished controls and experimental stuff may require guinget to be restarted to take full effect. Please be aware that if the guinget cache is what's broken, you can use the `Delete cache files in Local AppData` button under `Tools>Options...>Maintenance`. However, if winget's cache is broken, that may require resetting its sources from a command-line since there's no option for that in guinget yet.
 
 ## Switch tabs with mouse scroll wheel
 

--- a/docs/How-to-use.md
+++ b/docs/How-to-use.md
@@ -51,11 +51,20 @@ Please note this isn't available if more than one package is selected at once.
 ## Marking a package
 
 Marking a package involves doing one of the following actions:
-- Double-click or right-click on a selected package and click `Action: Install`
-- Open the `Selected packages` menu and click `Action: Install`
-- Press `Ctrl+I` (capital "i", in case it looks similar to a lowercase "L")
-- Open the combobox dropdown menu for the selected package in the `Action` column (may take a few clicks to open the dropdown)
-- Move the cell selection over to the `Action` column with the arrow keys then press `spacebar`, then use the arrow keys to select `Install`. Pressing `Enter` will move to the next package row.
+- Double-click or right-click on a selected package and click one of these items:
+  - `Action: Install`
+  - `Action: Uninstall`
+  - `Action: Upgrade`
+- Open the `Selected packages` menu and click one of these:
+  - `Action: Install`
+  - `Action: Uninstall`
+  - `Action: Upgrade` (unfortunately there's no better character to have the accelerator on for "upgrade" than the letter "p" as far as I know)
+- Press one of these keyboard shortcuts:
+  - `Ctrl+I` for install (capital "i", in case it looks similar to a lowercase "L")
+  - `Ctrl+U` for uninstall
+  - `Ctrl+P` for upgrade
+- Open the combobox dropdown menu for the selected package in the `Action` column and use one of the items in the list (may take a few clicks to open the dropdown)
+- Move the cell selection over to the `Action` column with the arrow keys then press `spacebar`, then use the arrow keys to select `Install`, `Uninstall`, or `Upgrade`. Pressing `Enter` will move to the next package row.
 
 This also applies to marking a package for uninstallation (once that's available), or for marking a package as one you want to ignore (ignoring is `Do nothing`).
 

--- a/docs/How-to-use.md
+++ b/docs/How-to-use.md
@@ -123,7 +123,7 @@ You can search for packages using the search bar in the toolbar at the top of th
 - Press `Ctrl+F` to automatically set focus to it
 - Use `Package list>Focus search box`
 
-After typing in what you want to search for, either press `Enter` or click the `Search` toolbar button. Once you've finished searching, you can press `Ctrl+F` again to set focus back to the package list if the search box is still focused. Please be aware that [using `Ctrl+A` to select all packages in the search results currently selects even non-filtered packages](https://github.com/DrewNaylor/guinget/issues/13).
+After typing in what you want to search for, either press `Enter` or click the `Search` toolbar button. Once you've finished searching, you can press `Ctrl+F` again to set focus back to the package list if the search box is still focused. Please be aware that [using `Ctrl+A` to select all packages in the search results currently selects even non-filtered packages](https://github.com/DrewNaylor/guinget/issues/13). That's not a problem if you mark all the ones you've selected in the search as we only mark visible packages.
 
 You can use `Esc`/`Escape` and press `Enter` or, as described below, double-click the sidebar search term list's `All` entry at the top to get back to the full package list.
 

--- a/docs/How-to-use.md
+++ b/docs/How-to-use.md
@@ -154,9 +154,13 @@ Search options can be changed from the `Tools>Options...>Search` tab, though the
 - `Package list>Search options...`
 - `Search options...` from the `Search` toolbar button dropdown menu
 
-Searches are now re-run after a cache update if there's text in the search box at the time of re-loading the package list, but you can turn that off by unchecking the `Re-run search after cache update` checkbox from the search options tab as described above.
-
-By default, using the selected package ID search feature will do an exact match, but you can turn that off using the `Use exact match for selected package ID search` checkbox in the search options tab as described above.
+The available options are as follows:
+- `Re-run search after cache update` checkbox
+  - Searches are now re-run after a cache update if there's text in the search box at the time of re-loading the package list, but you can turn that off if desired.
+- `Use exact match for selected package ID search` checkbox
+  - By default, using the selected package ID search feature will do an exact match, but you can turn that off if you want.
+- `Search when typing` checkbox
+  - Searches are performed after a configurable wait time with no typing that defaults to 325 milliseconds. You can change the wait time with the number box below the `Search when typing` checkbox.
 
 ## Edit winget settings
 

--- a/docs/How-to-use.md
+++ b/docs/How-to-use.md
@@ -93,19 +93,28 @@ If you have issues with winget while applying changes, you can reset the status 
 
 In case there's a package you forgot was marked or had its status reset and you don't want to apply changes to that package again without unmarking it or installing packages individually, you can right-click on it and choose `Skip selected package`. Any package with the `Current status` of `Skip` will be ignored until the `Apply changes` window is re-opened or the status for that package is reset.
 
-### Installation options
+### Apply changes options
 
-The following installation options are available:
+Options for `Apply changes` are accessible from both `Tools>Options...>Apply changes` and `Package list>Apply changes>Options... (linklabel)>Options: Apply Changes`. All the checkboxes that were in the `Apply changes` window are now in the `Options: Apply Changes` mini-form, and it now duplicates the `Apply changes` tab in the `Options` window for the most part.
+
+The following `Apply changes` options are available:
 - Running interactively: Check the `Run interactively (winget -i)` checkbox to have winget give you an interactive installer instead of an automated one. Even though this is usually used for installers, it should also work for uninstallers. Upgrades should work ok, too.
 - Elevated winget: check the `Elevate winget with UAC` checkbox to run winget as an administrator. This may help for some packages that complain about not having permissions when installing them. 
   - Typically it's used in case you usually run Windows from a standard/limited user account and have an administrator account for system modification and application installation. 
   - Please note that some installations of Windows might not be compatible with this option as it sometimes says it can't run winget if it's started from an elevated CMD. The issue seems to be that it can have trouble running APPX/MSIX packages elevated.
   - Since this is one of the only reasons winget would need to be run elevated, **it's not recommended to run guinget as administrator as of version 0.1.3**.
+- Specify version number...
+  - `When installing`
+  - `When uninstalling`
+  - `When upgrading`
+  - Note: Not specifying a version number will just use the latest version according to winget. You may want to use this when installing, but maybe not when upgrading or uninstalling as that may cause issues.
+- Automatically open the mini-form
+  - Mini-form text: `Automatically open this window when the Apply Changes window is opened`
+  - Options window text: `Automatically open the mini Options window when the Apply Changes window is opened`
+  
+There are also two buttons at the bottom of the mini-form: `Defaults` and `Close`. `Close` just closes the window and `Defaults` sets all the checkboxes back to default. Please be aware that the settings are automatically saved after resetting the checkboxes, as this window is intended to have the option to leave it open when applying changes and stuff, unlike the regular `Options` window.
 
 These will persist across closing the `Apply changes` window and restarting or upgrading guinget.
-Additionally, some options may also apply to actions like uninstallation.
-
-Installation options can also be changed from `Tools>Options...>Apply Changes`. This tab will have slightly more detailed names for the options, but they're similar to the equivalent ones in the `Apply changes` window. In some cases, this will be the only place to change certain options, but a link will be added to the `Apply changes` window to open this tab if that's ever the case.
 
 ## Searching for packages
 

--- a/docs/How-to-use.md
+++ b/docs/How-to-use.md
@@ -172,14 +172,14 @@ If something breaks, you can use the `Defaults` button in the bottom-left corner
 
 ## Switch tabs with mouse scroll wheel
 
-You can switch tab control tabs like the ones in the `Options` window using the mouse scroll wheel, just like many Linux applications. This is provided by [libscrollswitchtabs](https://drew-naylor.com/drews-libs/libscrollswitchtabs-how-to-use.html).
+You can switch tab control tabs like the ones in the `Options` window using the mouse scroll wheel, just like in many Linux applications. This is provided by [libscrollswitchtabs](https://drew-naylor.com/drews-libs/libscrollswitchtabs-how-to-use.html).
 
 ## Showing unfinished controls
 
 Controls that don't yet have their features implemented are hidden by default, but you can show them if you wish. Here's how to do this:
 1. Uncheck `Hide unfinished controls and experimental stuff` from `Tools>Options...>Experimental`.
-2. Reopen the tab.
+2. Click `OK`.
 
-You may need to restart guinget for this change to take full effect, though unchecking it should show everything without requiring a restart.
+You may need to restart guinget for this change to take full effect.
 
-Version 0.1.3 also hides [experimental options](experimental-options) behind this feature, so you'll have to show experimental controls if you want to change experimental options. Please note that experimental options will stay active even if the controls are hidden again.
+Version 0.1.3 and newer also hides [experimental options](experimental-options) behind this feature, so you'll have to show experimental controls if you want to change experimental options. Please note that experimental options will stay active even if the controls are hidden again.

--- a/docs/How-to-use.md
+++ b/docs/How-to-use.md
@@ -199,6 +199,17 @@ You can edit winget's settings using `Tools>Edit winget settings`. If you wish t
 
 If something breaks, you can use the `Defaults` button in the bottom-left corner of the `Options` window to reset everything, then click `OK` to save the default values. Some options like the one to hide unfinished controls and experimental stuff may require guinget to be restarted to take full effect. Please be aware that if the guinget cache is what's broken, you can use the `Delete cache files in Local AppData` button under `Tools>Options...>Maintenance`. However, if winget's cache is broken, that may require resetting its sources from a command-line since there's no option for that in guinget yet.
 
+## Maintenance
+
+Some maintenance-related buttons are available under `Tools>Options...>Maintenance`:
+
+- `Delete cache files in Roaming`
+  - Older versions of guinget stored their cache files in %AppData% instead of %LocalAppData%. You can delete them with this button, if you wish.
+- `Delete cache files in Local AppData`
+  - You can delete the cache files guinget uses with this button if you want to have a clean uninstall or if you're having issues. These files are stored in %LocalAppData%.
+  
+Eventually this tab will be moved to a sources manager app. If a particular folder doesn't exist, the button to delete it won't be available.
+
 ## Switch tabs with mouse scroll wheel
 
 You can switch tab control tabs like the ones in the `Options` window using the mouse scroll wheel, just like in many Linux applications. This is provided by [libscrollswitchtabs](https://drew-naylor.com/drews-libs/libscrollswitchtabs-how-to-use.html).

--- a/docs/How-to-use.md
+++ b/docs/How-to-use.md
@@ -65,9 +65,7 @@ Marking a package involves doing one of the following actions:
   - `Upgrade`
 - Move the cell selection over to the `Action` column with the arrow keys then press `spacebar`, then use the arrow keys to select `Install`, `Uninstall`, or `Upgrade`. Pressing `Enter` will move to the next package row.
 
-This also applies to marking a package for uninstallation (once that's available), or for marking a package as one you want to ignore (ignoring is `Do nothing`).
-
-If you wish to unmark or ignore a package, press `Ctrl+D` or use `Action: Do nothing` in either the package context menu or the `Selected packages` menu. You can also use the combobox dropdown menu as described above.
+This also applies to marking a package as one you want to ignore (ignoring is `Do nothing`). If you wish to unmark or ignore a package, press `Ctrl+D` or use `Action: Do nothing` in either the package context menu or the `Selected packages` menu. You can also use the combobox dropdown menu as described above.
 
 Using the arrow keys to move the cell selection may not work sometimes, as I had some issue getting it to work during testing.
 

--- a/docs/How-to-use_0.1.3.md
+++ b/docs/How-to-use_0.1.3.md
@@ -2,9 +2,9 @@
 
 [Homepage](https://drew-naylor.com/guinget)
 
-This guide is up-to-date as of version 0.2. You can get here at any time from `Help>How to use guinget`, or by pressing `F1`. There's a video showing [how to use guinget](https://youtu.be/t2OhzNE4yj0) available if you prefer watching videos, but it only covers up to version 0.1.0.1.
+This guide is up-to-date as of version 0.1.3. You can get here at any time from `Help>How to use guinget`, or by pressing `F1`. There's a video showing [how to use guinget](https://youtu.be/t2OhzNE4yj0) available if you prefer watching videos, but it only covers up to version 0.1.0.1.
 
-[Version 0.1.3's usage guide](https://drew-naylor.com/guinget/How-to-use_0.1.3) is available if you need one for that version.
+[Version 0.1.2's usage guide](https://drew-naylor.com/guinget/How-to-use_0.1.2) isn't as refined, but it only describes features that are in version 0.1.2.
 
 ## Running guinget as administrator
 

--- a/docs/experimental-options.md
+++ b/docs/experimental-options.md
@@ -18,36 +18,6 @@ If unchecked, these options and other unfinished controls will remain visible ev
 
 Defaults to `True`/checked.
 
-## Update and load package list from winget's default community database
-
-Config file setting name:
-`LoadFromSqliteDb`
-
-Description:
-This will ensure guinget only displays packages winget's default source knows about and may be faster in some cases. Details will still be loaded from manifests.
-
-Notes:
-- The package list will be loaded using the same SQLite database as winget uses by default, located at https://winget.azureedge.net/cache/source.msix. This still relies on the manifests to get the package descriptions as those aren't directly available in the database, though.
-- Each package version is listed as a separate entry even when loading from the database, though using the database will make sure only packages winget can display right now are shown.
-- Some packages may be in a different order compared to loading all the manifests at once, but this shouldn't be much of an issue, and clicking the Package column header should sort them as expected.
-- Loading the descriptions may still take a bit as we have to take the package ID and version number and figure out where its manifest is, instead of just grabbing all the manifests and loading from them. In case we can't find a package's manifest, we'll just look through all the manifests until we find the right one. Figuring out where each package's manifest is stored is done in three ways:
-  - If replacing all instances of "." in the package ID and appending the package version to the end of the path along with ".yaml" finds a file that exists, then that's great and we'll use that file. This is the fastest method.
-  - If that doesn't work, then we only replace the first instance of the "." in the ID and try again with the version thing. This should be fast, too.
-  - If neither of those work, then we fall back to looking for manifests with the package's version number in their filename, opening each file match we find, checking the package ID in the file, and if it's a match, we use it. Otherwise we keep going until finding the manifest. At the moment, this doesn't check to make sure that a file exists, so it may crash if it can't find a matching manifest. The Visual Studio profiler says there's a lot of garbage collection going on as well, so this will probably need to be changed to something like Using to keep automatic garbage collection to a minimum.
-- You may need to manually delete the package list cache located in `%AppData%\winget-frontends\source` before using the database as it may get confused if the manifest directory (`winget-pkgs`) exists but the database one (`winget-db`) doesn't. This'll be changed when loading from the database is officially supported.
-
-Defaults to `False`/unchecked.
-
-## Load only the latest version of each package
-
-Config file setting name:
-`OnlyDisplayLatestPackageVersion`
-
-Description:
-Some packages may display a version number that's not really the latest version. Not sure how to fix this at the moment. Requires loading from the community database checkbox to be checked.
-
-Defaults to `False`/unchecked.
-
 ## Use 7-Zip to extract manifests and database
 
 Config file setting name:
@@ -93,31 +63,12 @@ During testing on my laptop, using 7-Zip and Robocopy reduced the cache updating
 
 Closing guinget before the cache update is completed if using Robocopy and/or 7-Zip will leave those programs open and you'll have to close them manually. This should be changed in a future version to automatically close them when closing guinget.
 
-## Search when typing
-
-Config file setting name:
-`SearchWhenTyping`
-
-Instead of requiring you to press `Enter` or click `Search` on the toolbar, you can just wait a bit (325 milliseconds by default) for search to run automatically. This feature would probably have been a regular, non-experimental one had it been implemented sooner and not within a week of the expected release phase.
-
-Defaults to `False`/unchecked.
-
-### Wait time (ms)
-
-Config file setting name:
-`SearchWhenTypingTimerInterval`
-
-This is how long it'll wait after you finish typing before running a search (in milliseconds).<br>
-Minimum value is `1`, and maximum value is `9999`.
-
-Defaults to `325`.
-
 ## HiDPI Mode
 
 Config file setting name:
 `HiDPIMode`
 
-For now, only doubles the height of items in the package list.<br>
+For now, only doubles the height of items in the package list and the `Apply changes` window.<br>
 May eventually be expanded to cover the rest of the controls that are difficult to use on HiDPI devices.
 
 Defaults to `False`/unchecked.

--- a/docs/experimental-options.md
+++ b/docs/experimental-options.md
@@ -2,9 +2,9 @@
 
 [Homepage](https://drew-naylor.com/guinget) &bull; [Back to usage guide](https://drew-naylor.com/guinget/How-to-use)
 
-This is a list of experimental options as of version 0.1.3, and they can all be configured from `Tools>Options...>Experimental`. To show the controls on this tab, first uncheck the `Hide unfinished controls and experimental stuff` checkbox on the `Tools>Options...>Experimental` tab, then reopen the tab. You may need to restart guinget for this change to take full effect, though unchecking it should show everything without requiring a restart.
+This is a list of experimental options as of version 0.2, and they can all be configured from `Tools>Options...>Experimental`. To show the controls on this tab, first uncheck the `Hide unfinished controls and experimental stuff` checkbox on the `Tools>Options...>Experimental` tab, then click `OK`. You may need to restart guinget for this change to take full effect, though unchecking it should show everything without requiring a restart.
 
-If something breaks, you can use the `Defaults` button in the bottom-left corner of the `Options` window to reset everything, then click `OK` to save the default values. Some options like the one to hide unfinished controls and experimental stuff requires/may require guinget to be restarted to take full effect. Please be aware that if the guinget cache is what's broken, you'll have to manually delete it from `%AppData%\winget-frontends\source` for now. However, if winget's cache is broken, that may require resetting its sources from a command-line since there's no option for that in guinget yet.
+If something breaks, you can use the `Defaults` button in the bottom-left corner of the `Options` window to reset everything, then click `OK` to save the default values. Some options like the one to hide unfinished controls and experimental stuff requires/may require guinget to be restarted to take full effect. Please be aware that if the guinget cache is what's broken, you can use the `Delete cache files in Local AppData` button under `Tools>Options...>Maintenance`. However, if winget's cache is broken, that may require resetting its sources from a command-line since there's no option for that in guinget yet.
 
 ## Hide unfinished controls and experimental stuff
 

--- a/guinget/App.config
+++ b/guinget/App.config
@@ -107,7 +107,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Data.Sqlite" publicKeyToken="adb9793829ddae60" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-5.0.3.0" newVersion="5.0.3.0" />
+        <bindingRedirect oldVersion="0.0.0.0-5.0.4.0" newVersion="5.0.4.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/guinget/MainWindow.Designer.vb
+++ b/guinget/MainWindow.Designer.vb
@@ -201,14 +201,14 @@ Partial Class aaformMainWindow
         'zFileMenuSeparator2
         '
         Me.zFileMenuSeparator2.Name = "zFileMenuSeparator2"
-        Me.zFileMenuSeparator2.Size = New System.Drawing.Size(204, 6)
+        Me.zFileMenuSeparator2.Size = New System.Drawing.Size(299, 6)
         '
         'RunCMDToolStripMenuItem
         '
         Me.RunCMDToolStripMenuItem.Name = "RunCMDToolStripMenuItem"
         Me.RunCMDToolStripMenuItem.ShortcutKeys = CType(((System.Windows.Forms.Keys.Control Or System.Windows.Forms.Keys.Alt) _
             Or System.Windows.Forms.Keys.T), System.Windows.Forms.Keys)
-        Me.RunCMDToolStripMenuItem.Size = New System.Drawing.Size(279, 22)
+        Me.RunCMDToolStripMenuItem.Size = New System.Drawing.Size(302, 22)
         Me.RunCMDToolStripMenuItem.Text = "Run &CMD"
         '
         'RunCMDElevatedToolStripMenuItem
@@ -223,13 +223,13 @@ Partial Class aaformMainWindow
         'zFileMenuSeparator
         '
         Me.zFileMenuSeparator.Name = "zFileMenuSeparator"
-        Me.zFileMenuSeparator.Size = New System.Drawing.Size(204, 6)
+        Me.zFileMenuSeparator.Size = New System.Drawing.Size(299, 6)
         '
         'ExitToolStripMenuItem
         '
         Me.ExitToolStripMenuItem.Name = "ExitToolStripMenuItem"
         Me.ExitToolStripMenuItem.ShortcutKeys = CType((System.Windows.Forms.Keys.Alt Or System.Windows.Forms.Keys.F4), System.Windows.Forms.Keys)
-        Me.ExitToolStripMenuItem.Size = New System.Drawing.Size(207, 22)
+        Me.ExitToolStripMenuItem.Size = New System.Drawing.Size(302, 22)
         Me.ExitToolStripMenuItem.Text = "E&xit"
         '
         'ViewToolStripMenuItem
@@ -742,6 +742,7 @@ Partial Class aaformMainWindow
         'toolstriptextboxSearch
         '
         Me.toolstriptextboxSearch.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle
+        Me.toolstriptextboxSearch.Font = New System.Drawing.Font("Segoe UI", 9.0!)
         Me.toolstriptextboxSearch.Name = "toolstriptextboxSearch"
         Me.toolstriptextboxSearch.Size = New System.Drawing.Size(200, 25)
         '

--- a/guinget/MainWindow.resx
+++ b/guinget/MainWindow.resx
@@ -123,9 +123,6 @@
   <metadata name="contextmenustripPackageMenu.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>357, 17</value>
   </metadata>
-  <data name="textboxPackageDetails.Text" xml:space="preserve">
-    <value>No package is selected or the package list hasn't been loaded yet. You can load the package list by using the Refresh cache toolbar button, by going to Package list&gt;Refresh cache, or by pressing Ctrl+R.</value>
-  </data>
   <metadata name="PkgAction.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
@@ -150,6 +147,9 @@
   <metadata name="Manifest.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
+  <data name="textboxPackageDetails.Text" xml:space="preserve">
+    <value>No package is selected or the package list hasn't been loaded yet. You can load the package list by using the Refresh cache toolbar button, by going to Package list&gt;Refresh cache, or by pressing Ctrl+R.</value>
+  </data>
   <metadata name="toolstripMainWindow.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>153, 17</value>
   </metadata>

--- a/guinget/MiniApplyChangesOptionsForm.Designer.vb
+++ b/guinget/MiniApplyChangesOptionsForm.Designer.vb
@@ -43,7 +43,7 @@ Partial Class MiniApplyChangesOptionsForm
         Me.labelWhyElevate.AutoSize = True
         Me.labelWhyElevate.Location = New System.Drawing.Point(20, 43)
         Me.labelWhyElevate.Name = "labelWhyElevate"
-        Me.labelWhyElevate.Size = New System.Drawing.Size(287, 65)
+        Me.labelWhyElevate.Size = New System.Drawing.Size(292, 65)
         Me.labelWhyElevate.TabIndex = 5
         Me.labelWhyElevate.Text = resources.GetString("labelWhyElevate.Text")
         '

--- a/guinget/MiniApplyChangesOptionsForm.resx
+++ b/guinget/MiniApplyChangesOptionsForm.resx
@@ -119,10 +119,10 @@
   </resheader>
   <data name="labelWhyElevate.Text" xml:space="preserve">
     <value>Some packages require winget to be run elevated for them
-to install properly if your account is a limited one.
-This may not work on Windows 10 version 2004 as it
+to install properly, particularly if your account is a limited one.
+This may not work on some Windows installations as it
 might say it couldn't run winget. The issue seems to be that
-it has trouble running APPX/MSIX packages elevated now.</value>
+it can have trouble running APPX/MSIX packages elevated.</value>
   </data>
   <data name="labelAboutNotSpecifyingVersionNumbers.Text" xml:space="preserve">
     <value>Not specifying a version number will just use the latest

--- a/guinget/OptionsWindow.Designer.vb
+++ b/guinget/OptionsWindow.Designer.vb
@@ -27,6 +27,10 @@ Partial Class OptionsWindow
         Me.buttonDefaults = New System.Windows.Forms.Button()
         Me.tabcontrolOptions = New System.Windows.Forms.TabControl()
         Me.tabpageRefreshCache = New System.Windows.Forms.TabPage()
+        Me.checkboxLoadFromDatabase = New System.Windows.Forms.CheckBox()
+        Me.labelLoadLatestVersion = New System.Windows.Forms.Label()
+        Me.labelLoadFromManifests = New System.Windows.Forms.Label()
+        Me.checkboxShowOnlyLatestVersions = New System.Windows.Forms.CheckBox()
         Me.labelDeleteTempFilesAfterRefresh = New System.Windows.Forms.Label()
         Me.checkboxDeleteTempFilesAfterRefresh = New System.Windows.Forms.CheckBox()
         Me.tabpageSearch = New System.Windows.Forms.TabPage()
@@ -79,10 +83,6 @@ Partial Class OptionsWindow
         Me.buttonCancel = New System.Windows.Forms.Button()
         Me.buttonOk = New System.Windows.Forms.Button()
         Me.SevenZExeOpenFileDialog = New System.Windows.Forms.OpenFileDialog()
-        Me.checkboxLoadFromDatabase = New System.Windows.Forms.CheckBox()
-        Me.labelLoadLatestVersion = New System.Windows.Forms.Label()
-        Me.labelLoadFromManifests = New System.Windows.Forms.Label()
-        Me.checkboxShowOnlyLatestVersions = New System.Windows.Forms.CheckBox()
         Me.tablelayoutpanelOptions.SuspendLayout()
         Me.tabcontrolOptions.SuspendLayout()
         Me.tabpageRefreshCache.SuspendLayout()
@@ -165,6 +165,51 @@ Partial Class OptionsWindow
         Me.tabpageRefreshCache.TabIndex = 5
         Me.tabpageRefreshCache.Text = "Refresh Cache"
         Me.tabpageRefreshCache.UseVisualStyleBackColor = True
+        '
+        'checkboxLoadFromDatabase
+        '
+        Me.checkboxLoadFromDatabase.AutoSize = True
+        Me.checkboxLoadFromDatabase.CheckAlign = System.Drawing.ContentAlignment.TopLeft
+        Me.checkboxLoadFromDatabase.Location = New System.Drawing.Point(6, 55)
+        Me.checkboxLoadFromDatabase.Margin = New System.Windows.Forms.Padding(3, 3, 3, 0)
+        Me.checkboxLoadFromDatabase.Name = "checkboxLoadFromDatabase"
+        Me.checkboxLoadFromDatabase.Size = New System.Drawing.Size(229, 30)
+        Me.checkboxLoadFromDatabase.TabIndex = 4
+        Me.checkboxLoadFromDatabase.Text = "Update and load package list from winget's" & Global.Microsoft.VisualBasic.ChrW(13) & Global.Microsoft.VisualBasic.ChrW(10) & "default community database"
+        Me.checkboxLoadFromDatabase.UseVisualStyleBackColor = True
+        '
+        'labelLoadLatestVersion
+        '
+        Me.labelLoadLatestVersion.AutoSize = True
+        Me.labelLoadLatestVersion.Location = New System.Drawing.Point(41, 144)
+        Me.labelLoadLatestVersion.Name = "labelLoadLatestVersion"
+        Me.labelLoadLatestVersion.Size = New System.Drawing.Size(271, 52)
+        Me.labelLoadLatestVersion.TabIndex = 7
+        Me.labelLoadLatestVersion.Text = "Some packages may display a version number that's not" & Global.Microsoft.VisualBasic.ChrW(13) & Global.Microsoft.VisualBasic.ChrW(10) & "really the latest version." &
+    " Not sure how to fix this at the" & Global.Microsoft.VisualBasic.ChrW(13) & Global.Microsoft.VisualBasic.ChrW(10) & "moment. Requires loading from the community" & Global.Microsoft.VisualBasic.ChrW(13) & Global.Microsoft.VisualBasic.ChrW(10) & "d" &
+    "atabase checkbox to be checked."
+        '
+        'labelLoadFromManifests
+        '
+        Me.labelLoadFromManifests.AutoSize = True
+        Me.labelLoadFromManifests.Location = New System.Drawing.Point(21, 85)
+        Me.labelLoadFromManifests.Name = "labelLoadFromManifests"
+        Me.labelLoadFromManifests.Size = New System.Drawing.Size(270, 39)
+        Me.labelLoadFromManifests.TabIndex = 5
+        Me.labelLoadFromManifests.Text = "This will ensure guinget only displays packages winget's" & Global.Microsoft.VisualBasic.ChrW(13) & Global.Microsoft.VisualBasic.ChrW(10) & "default source knows ab" &
+    "out and may be faster" & Global.Microsoft.VisualBasic.ChrW(13) & Global.Microsoft.VisualBasic.ChrW(10) & "in some cases. Details will still be loaded from manifest" &
+    "s."
+        '
+        'checkboxShowOnlyLatestVersions
+        '
+        Me.checkboxShowOnlyLatestVersions.AutoSize = True
+        Me.checkboxShowOnlyLatestVersions.Location = New System.Drawing.Point(24, 127)
+        Me.checkboxShowOnlyLatestVersions.Margin = New System.Windows.Forms.Padding(3, 3, 3, 0)
+        Me.checkboxShowOnlyLatestVersions.Name = "checkboxShowOnlyLatestVersions"
+        Me.checkboxShowOnlyLatestVersions.Size = New System.Drawing.Size(239, 17)
+        Me.checkboxShowOnlyLatestVersions.TabIndex = 6
+        Me.checkboxShowOnlyLatestVersions.Text = "Load only the latest version of each package"
+        Me.checkboxShowOnlyLatestVersions.UseVisualStyleBackColor = True
         '
         'labelDeleteTempFilesAfterRefresh
         '
@@ -402,7 +447,7 @@ Partial Class OptionsWindow
         Me.labelWhyElevate.AutoSize = True
         Me.labelWhyElevate.Location = New System.Drawing.Point(23, 46)
         Me.labelWhyElevate.Name = "labelWhyElevate"
-        Me.labelWhyElevate.Size = New System.Drawing.Size(287, 65)
+        Me.labelWhyElevate.Size = New System.Drawing.Size(292, 65)
         Me.labelWhyElevate.TabIndex = 2
         Me.labelWhyElevate.Text = resources.GetString("labelWhyElevate.Text")
         '
@@ -719,51 +764,6 @@ Partial Class OptionsWindow
         Me.SevenZExeOpenFileDialog.FileName = "7z.exe"
         Me.SevenZExeOpenFileDialog.Filter = "EXE files|*.exe|All files|*.*"
         Me.SevenZExeOpenFileDialog.Title = "Browse for 7z.exe"
-        '
-        'checkboxLoadFromDatabase
-        '
-        Me.checkboxLoadFromDatabase.AutoSize = True
-        Me.checkboxLoadFromDatabase.CheckAlign = System.Drawing.ContentAlignment.TopLeft
-        Me.checkboxLoadFromDatabase.Location = New System.Drawing.Point(6, 55)
-        Me.checkboxLoadFromDatabase.Margin = New System.Windows.Forms.Padding(3, 3, 3, 0)
-        Me.checkboxLoadFromDatabase.Name = "checkboxLoadFromDatabase"
-        Me.checkboxLoadFromDatabase.Size = New System.Drawing.Size(229, 30)
-        Me.checkboxLoadFromDatabase.TabIndex = 4
-        Me.checkboxLoadFromDatabase.Text = "Update and load package list from winget's" & Global.Microsoft.VisualBasic.ChrW(13) & Global.Microsoft.VisualBasic.ChrW(10) & "default community database"
-        Me.checkboxLoadFromDatabase.UseVisualStyleBackColor = True
-        '
-        'labelLoadLatestVersion
-        '
-        Me.labelLoadLatestVersion.AutoSize = True
-        Me.labelLoadLatestVersion.Location = New System.Drawing.Point(41, 144)
-        Me.labelLoadLatestVersion.Name = "labelLoadLatestVersion"
-        Me.labelLoadLatestVersion.Size = New System.Drawing.Size(271, 52)
-        Me.labelLoadLatestVersion.TabIndex = 7
-        Me.labelLoadLatestVersion.Text = "Some packages may display a version number that's not" & Global.Microsoft.VisualBasic.ChrW(13) & Global.Microsoft.VisualBasic.ChrW(10) & "really the latest version." &
-    " Not sure how to fix this at the" & Global.Microsoft.VisualBasic.ChrW(13) & Global.Microsoft.VisualBasic.ChrW(10) & "moment. Requires loading from the community" & Global.Microsoft.VisualBasic.ChrW(13) & Global.Microsoft.VisualBasic.ChrW(10) & "d" &
-    "atabase checkbox to be checked."
-        '
-        'labelLoadFromManifests
-        '
-        Me.labelLoadFromManifests.AutoSize = True
-        Me.labelLoadFromManifests.Location = New System.Drawing.Point(21, 85)
-        Me.labelLoadFromManifests.Name = "labelLoadFromManifests"
-        Me.labelLoadFromManifests.Size = New System.Drawing.Size(270, 39)
-        Me.labelLoadFromManifests.TabIndex = 5
-        Me.labelLoadFromManifests.Text = "This will ensure guinget only displays packages winget's" & Global.Microsoft.VisualBasic.ChrW(13) & Global.Microsoft.VisualBasic.ChrW(10) & "default source knows ab" &
-    "out and may be faster" & Global.Microsoft.VisualBasic.ChrW(13) & Global.Microsoft.VisualBasic.ChrW(10) & "in some cases. Details will still be loaded from manifest" &
-    "s."
-        '
-        'checkboxShowOnlyLatestVersions
-        '
-        Me.checkboxShowOnlyLatestVersions.AutoSize = True
-        Me.checkboxShowOnlyLatestVersions.Location = New System.Drawing.Point(24, 127)
-        Me.checkboxShowOnlyLatestVersions.Margin = New System.Windows.Forms.Padding(3, 3, 3, 0)
-        Me.checkboxShowOnlyLatestVersions.Name = "checkboxShowOnlyLatestVersions"
-        Me.checkboxShowOnlyLatestVersions.Size = New System.Drawing.Size(239, 17)
-        Me.checkboxShowOnlyLatestVersions.TabIndex = 6
-        Me.checkboxShowOnlyLatestVersions.Text = "Load only the latest version of each package"
-        Me.checkboxShowOnlyLatestVersions.UseVisualStyleBackColor = True
         '
         'OptionsWindow
         '

--- a/guinget/OptionsWindow.resx
+++ b/guinget/OptionsWindow.resx
@@ -125,10 +125,10 @@ uninstalling as that may cause issues.</value>
   </data>
   <data name="labelWhyElevate.Text" xml:space="preserve">
     <value>Some packages require winget to be run elevated for them
-to install properly if your account is a limited one.
-This may not work on Windows 10 version 2004 as it
+to install properly, particularly if your account is a limited one.
+This may not work on some Windows installations as it
 might say it couldn't run winget. The issue seems to be that
-it has trouble running APPX/MSIX packages elevated now.</value>
+it can have trouble running APPX/MSIX packages elevated.</value>
   </data>
   <data name="labelDefaultSourceNameDescription.Text" xml:space="preserve">
     <value>In case the default source for winget is renamed,

--- a/guinget/guinget.vbproj
+++ b/guinget/guinget.vbproj
@@ -81,8 +81,8 @@
     <Reference Include="libscrollswitchtabs">
       <HintPath>..\libs\libscrollswitchtabs.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Data.Sqlite, Version=5.0.3.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Data.Sqlite.Core.5.0.3\lib\netstandard2.0\Microsoft.Data.Sqlite.dll</HintPath>
+    <Reference Include="Microsoft.Data.Sqlite, Version=5.0.4.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Data.Sqlite.Core.5.0.4\lib\netstandard2.0\Microsoft.Data.Sqlite.dll</HintPath>
     </Reference>
     <Reference Include="SQLitePCLRaw.batteries_v2, Version=2.0.4.976, Culture=neutral, PublicKeyToken=8226ea5df37bcae9, processorArchitecture=MSIL">
       <HintPath>..\packages\SQLitePCLRaw.bundle_e_sqlite3.2.0.4\lib\net461\SQLitePCLRaw.batteries_v2.dll</HintPath>

--- a/guinget/packages.config
+++ b/guinget/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Data.Sqlite" version="5.0.3" targetFramework="net48" />
-  <package id="Microsoft.Data.Sqlite.Core" version="5.0.3" targetFramework="net48" />
+  <package id="Microsoft.Data.Sqlite" version="5.0.4" targetFramework="net48" />
+  <package id="Microsoft.Data.Sqlite.Core" version="5.0.4" targetFramework="net48" />
   <package id="SQLitePCLRaw.bundle_e_sqlite3" version="2.0.4" targetFramework="net48" />
   <package id="SQLitePCLRaw.core" version="2.0.4" targetFramework="net48" />
   <package id="SQLitePCLRaw.lib.e_sqlite3" version="2.0.4" targetFramework="net48" />

--- a/libguinget/libguinget.vbproj
+++ b/libguinget/libguinget.vbproj
@@ -50,8 +50,8 @@
     <OptionInfer>On</OptionInfer>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.Data.Sqlite, Version=5.0.3.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Data.Sqlite.Core.5.0.3\lib\netstandard2.0\Microsoft.Data.Sqlite.dll</HintPath>
+    <Reference Include="Microsoft.Data.Sqlite, Version=5.0.4.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Data.Sqlite.Core.5.0.4\lib\netstandard2.0\Microsoft.Data.Sqlite.dll</HintPath>
     </Reference>
     <Reference Include="SQLitePCLRaw.batteries_v2, Version=2.0.4.976, Culture=neutral, PublicKeyToken=8226ea5df37bcae9, processorArchitecture=MSIL">
       <HintPath>..\packages\SQLitePCLRaw.bundle_e_sqlite3.2.0.4\lib\net461\SQLitePCLRaw.batteries_v2.dll</HintPath>

--- a/libguinget/packages.config
+++ b/libguinget/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Data.Sqlite" version="5.0.3" targetFramework="net48" />
-  <package id="Microsoft.Data.Sqlite.Core" version="5.0.3" targetFramework="net48" />
+  <package id="Microsoft.Data.Sqlite" version="5.0.4" targetFramework="net48" />
+  <package id="Microsoft.Data.Sqlite.Core" version="5.0.4" targetFramework="net48" />
   <package id="SQLitePCLRaw.bundle_e_sqlite3" version="2.0.4" targetFramework="net48" />
   <package id="SQLitePCLRaw.core" version="2.0.4" targetFramework="net48" />
   <package id="SQLitePCLRaw.lib.e_sqlite3" version="2.0.4" targetFramework="net48" />


### PR DESCRIPTION
Besides adding a usage guide for v0.2, there were a few other things in here like updating the NuGet packages, wording updates in the Options window and mini-form for Apply changes options, and removing stuff from the experimental options page that's in the main usage guide now. 