### PR TITLE
Initial support for multi-file manifests.

### DIFF
--- a/guinget/MainWindow.vb
+++ b/guinget/MainWindow.vb
@@ -505,7 +505,7 @@ Public Class aaformMainWindow
         SelectedPackagesSearchForLastSelectedID.Enabled = AllowFunctions
     End Sub
 
-    Private Sub ShowSelectedPackageDetails()
+    Private Async Sub ShowSelectedPackageDetails()
 
         ' We can now display the package details while making sure the manifest isn't
         ' nothing.
@@ -517,20 +517,27 @@ Public Class aaformMainWindow
             ' Take text from the Manifest cell and use that
             ' file path to display text in the details textbox.
             Dim ManifestPath As String = datagridviewPackageList.Item(7, datagridviewPackageList.SelectedRows.Item(0).Index).Value.ToString
-            ' Display full manifest in details textbox.
-            textboxPackageDetails.Text = My.Computer.FileSystem.ReadAllText(ManifestPath).Replace(vbLf, vbCrLf)
-        ElseIf datagridviewPackageList.SelectedRows.Count = 0 Then
-            ' If no rows are selected, say so in the same way Synaptic does,
-            ' because it says it in a way that's simple and nice.
-            ' This might not show up since rows are automatically selected when
-            ' they're loaded.
+            ' See if it's a multi-file manifest. If it is, we'll have to do some stuff.
+            If Await PackageTools.GetPackageInfoFromYamlAsync(ManifestPath, "ManifestType") = "version" Then
+                textboxPackageDetails.Text = "yo"
+            Else
+                ' It appears to be a single-file one.
+                ' Display full manifest in details textbox.
+                textboxPackageDetails.Text = My.Computer.FileSystem.ReadAllText(ManifestPath).Replace(vbLf, vbCrLf)
+            End If
 
-            ' TODO: Allow the user to choose whether to update the cache before
-            ' loading the package list, or just load the package list. This
-            ' should be a setting to allow for people to choose whether it
-            ' always updates the cache automatically, or have it ask to update every time.
-            ' This should be based on a time thing, so only update after 5 minutes for example.
-            textboxPackageDetails.Text = "No package is selected or the package list hasn't been loaded yet. " &
+        ElseIf datagridviewPackageList.SelectedRows.Count = 0 Then
+        ' If no rows are selected, say so in the same way Synaptic does,
+        ' because it says it in a way that's simple and nice.
+        ' This might not show up since rows are automatically selected when
+        ' they're loaded.
+
+        ' TODO: Allow the user to choose whether to update the cache before
+        ' loading the package list, or just load the package list. This
+        ' should be a setting to allow for people to choose whether it
+        ' always updates the cache automatically, or have it ask to update every time.
+        ' This should be based on a time thing, so only update after 5 minutes for example.
+        textboxPackageDetails.Text = "No package is selected or the package list hasn't been loaded yet. " &
                 "You can load the package list by using the Refresh cache toolbar button, by going to Package list" &
                 ">Refresh cache, or by pressing Ctrl+R."
         End If

--- a/guinget/MainWindow.vb
+++ b/guinget/MainWindow.vb
@@ -521,6 +521,7 @@ Public Class aaformMainWindow
             If Await PackageTools.GetPackageInfoFromYamlAsync(ManifestPath, "ManifestType") = "version" Then
                 ' Clear textbox.
                 textboxPackageDetails.Clear()
+
                 ' Add header text for the version file section.
                 textboxPackageDetails.Text = "Version manifest" & vbCrLf &
                                              "====================" & vbCrLf & vbCrLf
@@ -532,12 +533,16 @@ Public Class aaformMainWindow
                 textboxPackageDetails.Text = textboxPackageDetails.Text &
                                              "Default locale manifest" & vbCrLf &
                                              "=========================" & vbCrLf & vbCrLf
+
                 ' Find the default locale manifest.
-                Dim DefaultLocaleManifestPath As String = Await PackageTools.GetDefaultLocaleFilePathForMultiFileManifest(ManifestPath)
+                Dim DefaultLocaleManifestPath As String = Await PackageTools.GetMultiFileManifestPieceFilePath(ManifestPath, "defaultLocale")
                 ' Put default locale manifest into the details textbox.
                 textboxPackageDetails.Text = textboxPackageDetails.Text &
                                              My.Computer.FileSystem.ReadAllText(DefaultLocaleManifestPath).Replace(vbLf, vbCrLf) &
                                              vbCrLf
+
+                ' Find the installers manifest.
+                Dim InstallersManifestPath As String = Await PackageTools.GetMultiFileManifestPieceFilePath(ManifestPath, "installer")
             Else
                 ' It appears to be a single-file one.
                 ' Display full manifest in details textbox.

--- a/guinget/MainWindow.vb
+++ b/guinget/MainWindow.vb
@@ -175,6 +175,11 @@ Public Class aaformMainWindow
                 ' long description if it does.
                 ' Store the short description in a string so we don't have to read
                 ' the manifest multiple times just for the description comparison.
+                ' First check if the manifest is a single-file one or not.
+                'If Await PackageTools.GetPackageInfoFromYamlAsync(Row.Cells.Item(7).Value.ToString, "ManifestType") = "version" Then
+
+                'End If
+                ' Now do description stuff.
                 Dim ShortDescription As String = Await PackageTools.GetPackageInfoFromYamlAsync(Row.Cells.Item(7).Value.ToString, "ShortDescription")
                 If Row.Cells.Item(2).Value.ToString = ShortDescription Then
                     Row.Cells.Item(6).Value = Await PackageTools.GetPackageInfoFromYamlAsync(Row.Cells.Item(7).Value.ToString, "Description")
@@ -183,7 +188,7 @@ Public Class aaformMainWindow
                 End If
 
                 ' ManifestType for debugging. This'll be commented out until it's needed.
-                'Row.Cells.Item(8).Value = Await PackageTools.GetPackageInfoFromYamlAsync(Row.Cells.Item(7).Value.ToString, "ManifestType")
+                Row.Cells.Item(8).Value = Await PackageTools.GetPackageInfoFromYamlAsync(Row.Cells.Item(7).Value.ToString, "ManifestType")
 
                 ' Update the progressbar so it doesn't look frozen.
                 aaformMainWindow.toolstripprogressbarLoadingPackages.Value = Row.Index
@@ -209,15 +214,22 @@ Public Class aaformMainWindow
                 If PackageRow.Cells.Item(7).Value IsNot Nothing Then
                     ' Make sure the short description doesn't match the package ID, and use the
                     ' long description if it does.
-                    If PackageRow.Cells.Item(2).Value.ToString = Await PackageTools.GetPackageInfoFromYamlAsync(PackageRow.Cells.Item(7).Value.ToString, "ShortDescription") Then
+                    ' Store the short description in a string so we don't have to read
+                    ' the manifest multiple times just for the description comparison.
+                    Dim ShortDescription As String = Await PackageTools.GetPackageInfoFromYamlAsync(PackageRow.Cells.Item(7).Value.ToString, "ShortDescription")
+                    If PackageRow.Cells.Item(2).Value.ToString = ShortDescription Then
                         PackageRow.Cells.Item(6).Value = Await PackageTools.GetPackageInfoFromYamlAsync(PackageRow.Cells.Item(7).Value.ToString, "Description")
                     Else
-                        PackageRow.Cells.Item(6).Value = Await PackageTools.GetPackageInfoFromYamlAsync(PackageRow.Cells.Item(7).Value.ToString, "ShortDescription")
+                        PackageRow.Cells.Item(6).Value = ShortDescription
                     End If
                 Else
                     ' If the value in the manifest path cell is nothing, change the description.
                     PackageRow.Cells.Item(6).Value = "(Couldn't find manifest)"
                 End If
+
+                ' ManifestType for debugging. This'll be commented out until it's needed.
+                PackageRow.Cells.Item(8).Value = Await PackageTools.GetPackageInfoFromYamlAsync(PackageRow.Cells.Item(7).Value.ToString, "ManifestType")
+
                 ' Make the progress bar progress.
                 aaformMainWindow.toolstripprogressbarLoadingPackages.Value = PackageRow.Index
                 ' Update the statusbar to show the current info.

--- a/guinget/MainWindow.vb
+++ b/guinget/MainWindow.vb
@@ -163,6 +163,7 @@ Public Class aaformMainWindow
 
         ' Now we load the details for each row.
         If My.Settings.LoadFromSqliteDb = False Then
+#Region "Deprecated direct manifest loading."
             For Each Row As DataGridViewRow In aaformMainWindow.datagridviewPackageList.Rows
                 ' Load package ID column.
                 Row.Cells.Item(2).Value = Await PackageTools.GetPackageInfoFromYamlAsync(Row.Cells.Item(7).Value.ToString, "PackageIdentifier")
@@ -194,12 +195,13 @@ Public Class aaformMainWindow
                 aaformMainWindow.toolstripprogressbarLoadingPackages.Value = Row.Index
                 aaformMainWindow.statusbarMainWindow.Update()
             Next
+#End Region
 
+        ElseIf My.Settings.LoadFromSqliteDb = True Then
             ' In case there are manifests we can't find easily,
             ' we need to get them now.
             ' These have to be grabbed now or else updating the manifests
             ' will crash when the path doesn't exist.
-        ElseIf My.Settings.LoadFromSqliteDb = True Then
             PackageListTools.FallbackPathList = PackageListTools.GetManifests
 
             ' Now we need to load the manifests and the descriptions.

--- a/guinget/MainWindow.vb
+++ b/guinget/MainWindow.vb
@@ -222,7 +222,7 @@ Public Class aaformMainWindow
                         ' Remove file extension.
                         FileWithDescription = FileWithDescription.Remove(FileWithDescription.Length - 5)
                         ' Add default locale and re-add file extension.
-                        FileWithDescription = FileWithDescription & "." &
+                        FileWithDescription = FileWithDescription & ".locale." &
                             Await PackageTools.GetPackageInfoFromYamlAsync(PackageRow.Cells.Item(7).Value.ToString, "DefaultLocale") &
                             ".yaml"
                     End If

--- a/guinget/MainWindow.vb
+++ b/guinget/MainWindow.vb
@@ -524,25 +524,33 @@ Public Class aaformMainWindow
 
                 ' Add header text for the version file section.
                 textboxPackageDetails.Text = "Version manifest" & vbCrLf &
-                                             "====================" & vbCrLf & vbCrLf
+                                             "===================" & vbCrLf & vbCrLf
                 ' Put the version manifest in there.
                 textboxPackageDetails.Text = textboxPackageDetails.Text &
                                              My.Computer.FileSystem.ReadAllText(ManifestPath).Replace(vbLf, vbCrLf) &
                                              vbCrLf
+
                 ' Add header for the default locale manifest.
                 textboxPackageDetails.Text = textboxPackageDetails.Text &
                                              "Default locale manifest" & vbCrLf &
-                                             "=========================" & vbCrLf & vbCrLf
-
+                                             "==========================" & vbCrLf & vbCrLf
                 ' Find the default locale manifest.
                 Dim DefaultLocaleManifestPath As String = Await PackageTools.GetMultiFileManifestPieceFilePath(ManifestPath, "defaultLocale")
-                ' Put default locale manifest into the details textbox.
+                ' Put the default locale manifest into the details textbox.
                 textboxPackageDetails.Text = textboxPackageDetails.Text &
                                              My.Computer.FileSystem.ReadAllText(DefaultLocaleManifestPath).Replace(vbLf, vbCrLf) &
                                              vbCrLf
 
+                ' Add header for the default locale manifest.
+                textboxPackageDetails.Text = textboxPackageDetails.Text &
+                                             "Installers manifest" & vbCrLf &
+                                             "======================" & vbCrLf & vbCrLf
                 ' Find the installers manifest.
                 Dim InstallersManifestPath As String = Await PackageTools.GetMultiFileManifestPieceFilePath(ManifestPath, "installer")
+                ' Put the installers manifest into the details textbox.
+                textboxPackageDetails.Text = textboxPackageDetails.Text &
+                                             My.Computer.FileSystem.ReadAllText(InstallersManifestPath).Replace(vbLf, vbCrLf) &
+                                             vbCrLf
             Else
                 ' It appears to be a single-file one.
                 ' Display full manifest in details textbox.

--- a/guinget/MainWindow.vb
+++ b/guinget/MainWindow.vb
@@ -522,23 +522,23 @@ Public Class aaformMainWindow
                 ' Clear textbox.
                 textboxPackageDetails.Clear()
 
-                ' Add header text for the version file section.
-                textboxPackageDetails.Text = "Version manifest" & vbCrLf &
-                                             "==========================" & vbCrLf
-                ' Put the version manifest in there.
-                textboxPackageDetails.Text = textboxPackageDetails.Text &
-                                             My.Computer.FileSystem.ReadAllText(ManifestPath).Replace(vbLf, vbCrLf) &
-                                             vbCrLf
-
                 ' Add header for the default locale manifest.
-                textboxPackageDetails.Text = textboxPackageDetails.Text &
-                                             "Default locale manifest" & vbCrLf &
+                textboxPackageDetails.Text = "Default locale manifest" & vbCrLf &
                                              "==========================" & vbCrLf
                 ' Find the default locale manifest.
                 Dim DefaultLocaleManifestPath As String = Await PackageTools.GetMultiFileManifestPieceFilePath(ManifestPath, "defaultLocale")
                 ' Put the default locale manifest into the details textbox.
                 textboxPackageDetails.Text = textboxPackageDetails.Text &
                                              My.Computer.FileSystem.ReadAllText(DefaultLocaleManifestPath).Replace(vbLf, vbCrLf) &
+                                             vbCrLf
+
+                ' Add header text for the version file section.
+                textboxPackageDetails.Text = textboxPackageDetails.Text &
+                                             "Version manifest" & vbCrLf &
+                                             "==========================" & vbCrLf
+                ' Put the version manifest in there.
+                textboxPackageDetails.Text = textboxPackageDetails.Text &
+                                             My.Computer.FileSystem.ReadAllText(ManifestPath).Replace(vbLf, vbCrLf) &
                                              vbCrLf
 
                 ' Add header for the default locale manifest.

--- a/guinget/MainWindow.vb
+++ b/guinget/MainWindow.vb
@@ -524,7 +524,7 @@ Public Class aaformMainWindow
 
                 ' Add header text for the version file section.
                 textboxPackageDetails.Text = "Version manifest" & vbCrLf &
-                                             "===================" & vbCrLf & vbCrLf
+                                             "===================" & vbCrLf
                 ' Put the version manifest in there.
                 textboxPackageDetails.Text = textboxPackageDetails.Text &
                                              My.Computer.FileSystem.ReadAllText(ManifestPath).Replace(vbLf, vbCrLf) &
@@ -533,7 +533,7 @@ Public Class aaformMainWindow
                 ' Add header for the default locale manifest.
                 textboxPackageDetails.Text = textboxPackageDetails.Text &
                                              "Default locale manifest" & vbCrLf &
-                                             "==========================" & vbCrLf & vbCrLf
+                                             "==========================" & vbCrLf
                 ' Find the default locale manifest.
                 Dim DefaultLocaleManifestPath As String = Await PackageTools.GetMultiFileManifestPieceFilePath(ManifestPath, "defaultLocale")
                 ' Put the default locale manifest into the details textbox.
@@ -544,7 +544,7 @@ Public Class aaformMainWindow
                 ' Add header for the default locale manifest.
                 textboxPackageDetails.Text = textboxPackageDetails.Text &
                                              "Installers manifest" & vbCrLf &
-                                             "======================" & vbCrLf & vbCrLf
+                                             "======================" & vbCrLf
                 ' Find the installers manifest.
                 Dim InstallersManifestPath As String = Await PackageTools.GetMultiFileManifestPieceFilePath(ManifestPath, "installer")
                 ' Put the installers manifest into the details textbox.

--- a/guinget/MainWindow.vb
+++ b/guinget/MainWindow.vb
@@ -549,8 +549,7 @@ Public Class aaformMainWindow
                 Dim InstallersManifestPath As String = Await PackageTools.GetMultiFileManifestPieceFilePath(ManifestPath, "installer")
                 ' Put the installers manifest into the details textbox.
                 textboxPackageDetails.Text = textboxPackageDetails.Text &
-                                             My.Computer.FileSystem.ReadAllText(InstallersManifestPath).Replace(vbLf, vbCrLf) &
-                                             vbCrLf
+                                             My.Computer.FileSystem.ReadAllText(InstallersManifestPath).Replace(vbLf, vbCrLf)
             Else
                 ' It appears to be a single-file one.
                 ' Display full manifest in details textbox.
@@ -560,17 +559,17 @@ Public Class aaformMainWindow
             End If
 
         ElseIf datagridviewPackageList.SelectedRows.Count = 0 Then
-        ' If no rows are selected, say so in the same way Synaptic does,
-        ' because it says it in a way that's simple and nice.
-        ' This might not show up since rows are automatically selected when
-        ' they're loaded.
+            ' If no rows are selected, say so in the same way Synaptic does,
+            ' because it says it in a way that's simple and nice.
+            ' This might not show up since rows are automatically selected when
+            ' they're loaded.
 
-        ' TODO: Allow the user to choose whether to update the cache before
-        ' loading the package list, or just load the package list. This
-        ' should be a setting to allow for people to choose whether it
-        ' always updates the cache automatically, or have it ask to update every time.
-        ' This should be based on a time thing, so only update after 5 minutes for example.
-        textboxPackageDetails.Text = "No package is selected or the package list hasn't been loaded yet. " &
+            ' TODO: Allow the user to choose whether to update the cache before
+            ' loading the package list, or just load the package list. This
+            ' should be a setting to allow for people to choose whether it
+            ' always updates the cache automatically, or have it ask to update every time.
+            ' This should be based on a time thing, so only update after 5 minutes for example.
+            textboxPackageDetails.Text = "No package is selected or the package list hasn't been loaded yet. " &
                 "You can load the package list by using the Refresh cache toolbar button, by going to Package list" &
                 ">Refresh cache, or by pressing Ctrl+R."
         End If

--- a/guinget/MainWindow.vb
+++ b/guinget/MainWindow.vb
@@ -533,7 +533,11 @@ Public Class aaformMainWindow
                                              "Default locale manifest" & vbCrLf &
                                              "=========================" & vbCrLf & vbCrLf
                 ' Find the default locale manifest.
-
+                Dim DefaultLocaleManifestPath As String = Await PackageTools.GetDefaultLocaleFilePathForMultiFileManifest(ManifestPath)
+                ' Put default locale manifest into the details textbox.
+                textboxPackageDetails.Text = textboxPackageDetails.Text &
+                                             My.Computer.FileSystem.ReadAllText(DefaultLocaleManifestPath).Replace(vbLf, vbCrLf) &
+                                             vbCrLf
             Else
                 ' It appears to be a single-file one.
                 ' Display full manifest in details textbox.

--- a/guinget/MainWindow.vb
+++ b/guinget/MainWindow.vb
@@ -216,15 +216,26 @@ Public Class aaformMainWindow
                     ' long description if it does.
                     ' Store the short description in a string so we don't have to read
                     ' the manifest multiple times just for the description comparison.
-                    Dim ShortDescription As String = Await PackageTools.GetPackageInfoFromYamlAsync(PackageRow.Cells.Item(7).Value.ToString, "ShortDescription")
-                    If PackageRow.Cells.Item(2).Value.ToString = ShortDescription Then
-                        PackageRow.Cells.Item(6).Value = Await PackageTools.GetPackageInfoFromYamlAsync(PackageRow.Cells.Item(7).Value.ToString, "Description")
-                    Else
-                        PackageRow.Cells.Item(6).Value = ShortDescription
+                    ' First check if it's a single-file manifest or not.
+                    Dim FileWithDescription As String = PackageRow.Cells.Item(7).Value.ToString
+                    If Await PackageTools.GetPackageInfoFromYamlAsync(PackageRow.Cells.Item(7).Value.ToString, "ManifestType") = "version" Then
+                        ' Remove file extension.
+                        FileWithDescription = FileWithDescription.Remove(FileWithDescription.Length - 5)
+                        ' Add default locale and re-add file extension.
+                        FileWithDescription = FileWithDescription & "." &
+                            Await PackageTools.GetPackageInfoFromYamlAsync(PackageRow.Cells.Item(7).Value.ToString, "DefaultLocale") &
+                            ".yaml"
                     End If
-                Else
-                    ' If the value in the manifest path cell is nothing, change the description.
-                    PackageRow.Cells.Item(6).Value = "(Couldn't find manifest)"
+                    ' Now do the description stuff.
+                    Dim ShortDescription As String = Await PackageTools.GetPackageInfoFromYamlAsync(FileWithDescription, "ShortDescription")
+                    If PackageRow.Cells.Item(2).Value.ToString = ShortDescription Then
+                        PackageRow.Cells.Item(6).Value = Await PackageTools.GetPackageInfoFromYamlAsync(FileWithDescription, "Description")
+                    Else
+                            PackageRow.Cells.Item(6).Value = ShortDescription
+                        End If
+                    Else
+                        ' If the value in the manifest path cell is nothing, change the description.
+                        PackageRow.Cells.Item(6).Value = "(Couldn't find manifest)"
                 End If
 
                 ' ManifestType for debugging. This'll be commented out until it's needed.

--- a/guinget/MainWindow.vb
+++ b/guinget/MainWindow.vb
@@ -184,7 +184,7 @@ Public Class aaformMainWindow
                 End If
 
                 ' ManifestType for debugging. This'll be commented out until it's needed.
-                Row.Cells.Item(8).Value = Await PackageTools.GetPackageInfoFromYamlAsync(Row.Cells.Item(7).Value.ToString, "ManifestType")
+                'Row.Cells.Item(8).Value = Await PackageTools.GetPackageInfoFromYamlAsync(Row.Cells.Item(7).Value.ToString, "ManifestType")
 
                 ' Update the progressbar so it doesn't look frozen.
                 aaformMainWindow.toolstripprogressbarLoadingPackages.Value = Row.Index
@@ -232,7 +232,7 @@ Public Class aaformMainWindow
                 End If
 
                 ' ManifestType for debugging. This'll be commented out until it's needed.
-                PackageRow.Cells.Item(8).Value = Await PackageTools.GetPackageInfoFromYamlAsync(PackageRow.Cells.Item(7).Value.ToString, "ManifestType")
+                'PackageRow.Cells.Item(8).Value = Await PackageTools.GetPackageInfoFromYamlAsync(PackageRow.Cells.Item(7).Value.ToString, "ManifestType")
 
                 ' Make the progress bar progress.
                 aaformMainWindow.toolstripprogressbarLoadingPackages.Value = PackageRow.Index

--- a/guinget/MainWindow.vb
+++ b/guinget/MainWindow.vb
@@ -524,7 +524,7 @@ Public Class aaformMainWindow
 
                 ' Add header text for the version file section.
                 textboxPackageDetails.Text = "Version manifest" & vbCrLf &
-                                             "===================" & vbCrLf
+                                             "==========================" & vbCrLf
                 ' Put the version manifest in there.
                 textboxPackageDetails.Text = textboxPackageDetails.Text &
                                              My.Computer.FileSystem.ReadAllText(ManifestPath).Replace(vbLf, vbCrLf) &
@@ -544,7 +544,7 @@ Public Class aaformMainWindow
                 ' Add header for the default locale manifest.
                 textboxPackageDetails.Text = textboxPackageDetails.Text &
                                              "Installers manifest" & vbCrLf &
-                                             "======================" & vbCrLf
+                                             "==========================" & vbCrLf
                 ' Find the installers manifest.
                 Dim InstallersManifestPath As String = Await PackageTools.GetMultiFileManifestPieceFilePath(ManifestPath, "installer")
                 ' Put the installers manifest into the details textbox.
@@ -554,7 +554,9 @@ Public Class aaformMainWindow
             Else
                 ' It appears to be a single-file one.
                 ' Display full manifest in details textbox.
-                textboxPackageDetails.Text = My.Computer.FileSystem.ReadAllText(ManifestPath).Replace(vbLf, vbCrLf)
+                textboxPackageDetails.Text = "Manifest" & vbCrLf &
+                                             "==========================" & vbCrLf &
+                                             My.Computer.FileSystem.ReadAllText(ManifestPath).Replace(vbLf, vbCrLf)
             End If
 
         ElseIf datagridviewPackageList.SelectedRows.Count = 0 Then

--- a/guinget/MainWindow.vb
+++ b/guinget/MainWindow.vb
@@ -519,7 +519,21 @@ Public Class aaformMainWindow
             Dim ManifestPath As String = datagridviewPackageList.Item(7, datagridviewPackageList.SelectedRows.Item(0).Index).Value.ToString
             ' See if it's a multi-file manifest. If it is, we'll have to do some stuff.
             If Await PackageTools.GetPackageInfoFromYamlAsync(ManifestPath, "ManifestType") = "version" Then
-                textboxPackageDetails.Text = "yo"
+                ' Clear textbox.
+                textboxPackageDetails.Clear()
+                ' Add header text for the version file section.
+                textboxPackageDetails.Text = "Version manifest" & vbCrLf &
+                                             "====================" & vbCrLf & vbCrLf
+                ' Put the version manifest in there.
+                textboxPackageDetails.Text = textboxPackageDetails.Text &
+                                             My.Computer.FileSystem.ReadAllText(ManifestPath).Replace(vbLf, vbCrLf) &
+                                             vbCrLf
+                ' Add header for the default locale manifest.
+                textboxPackageDetails.Text = textboxPackageDetails.Text &
+                                             "Default locale manifest" & vbCrLf &
+                                             "=========================" & vbCrLf & vbCrLf
+                ' Find the default locale manifest.
+
             Else
                 ' It appears to be a single-file one.
                 ' Display full manifest in details textbox.

--- a/guinget/MainWindow.vb
+++ b/guinget/MainWindow.vb
@@ -222,7 +222,7 @@ Public Class aaformMainWindow
                     Dim FileWithDescription As String = PackageRow.Cells.Item(7).Value.ToString
                     If Await PackageTools.GetPackageInfoFromYamlAsync(PackageRow.Cells.Item(7).Value.ToString, "ManifestType") = "version" Then
                         ' Get the default locale path.
-                        FileWithDescription = Await PackageTools.GetDefaultLocaleFilePathForMultiFileManifest(FileWithDescription)
+                        FileWithDescription = Await PackageTools.GetMultiFileManifestPieceFilePath(FileWithDescription, "defaultLocale")
                     End If
                     ' Now do the description stuff.
                     Dim ShortDescription As String = Await PackageTools.GetPackageInfoFromYamlAsync(FileWithDescription, "ShortDescription")

--- a/guinget/MainWindow.vb
+++ b/guinget/MainWindow.vb
@@ -176,11 +176,6 @@ Public Class aaformMainWindow
                 ' long description if it does.
                 ' Store the short description in a string so we don't have to read
                 ' the manifest multiple times just for the description comparison.
-                ' First check if the manifest is a single-file one or not.
-                'If Await PackageTools.GetPackageInfoFromYamlAsync(Row.Cells.Item(7).Value.ToString, "ManifestType") = "version" Then
-
-                'End If
-                ' Now do description stuff.
                 Dim ShortDescription As String = Await PackageTools.GetPackageInfoFromYamlAsync(Row.Cells.Item(7).Value.ToString, "ShortDescription")
                 If Row.Cells.Item(2).Value.ToString = ShortDescription Then
                     Row.Cells.Item(6).Value = Await PackageTools.GetPackageInfoFromYamlAsync(Row.Cells.Item(7).Value.ToString, "Description")

--- a/guinget/MainWindow.vb
+++ b/guinget/MainWindow.vb
@@ -221,12 +221,8 @@ Public Class aaformMainWindow
                     ' First check if it's a single-file manifest or not.
                     Dim FileWithDescription As String = PackageRow.Cells.Item(7).Value.ToString
                     If Await PackageTools.GetPackageInfoFromYamlAsync(PackageRow.Cells.Item(7).Value.ToString, "ManifestType") = "version" Then
-                        ' Remove file extension.
-                        FileWithDescription = FileWithDescription.Remove(FileWithDescription.Length - 5)
-                        ' Add default locale and re-add file extension.
-                        FileWithDescription = FileWithDescription & ".locale." &
-                            Await PackageTools.GetPackageInfoFromYamlAsync(PackageRow.Cells.Item(7).Value.ToString, "DefaultLocale") &
-                            ".yaml"
+                        ' Get the default locale path.
+                        FileWithDescription = Await PackageTools.GetDefaultLocaleFilePathForMultiFileManifest(FileWithDescription)
                     End If
                     ' Now do the description stuff.
                     Dim ShortDescription As String = Await PackageTools.GetPackageInfoFromYamlAsync(FileWithDescription, "ShortDescription")

--- a/guinget/My Project/AssemblyInfo.vb
+++ b/guinget/My Project/AssemblyInfo.vb
@@ -31,5 +31,5 @@ Imports System.Runtime.InteropServices
 ' by using the '*' as shown below:
 ' <Assembly: AssemblyVersion("1.0.*")> 
 
-<Assembly: AssemblyVersion("0.2.0.1")>
-<Assembly: AssemblyFileVersion("0.2.0.1")>
+<Assembly: AssemblyVersion("0.2.0.2")>
+<Assembly: AssemblyFileVersion("0.2.0.2")>

--- a/guinget/guinget.vbproj
+++ b/guinget/guinget.vbproj
@@ -29,7 +29,7 @@
     <MapFileExtensions>false</MapFileExtensions>
     <ProductName>guinget</ProductName>
     <PublisherName>DrewNaylor</PublisherName>
-    <ApplicationRevision>1</ApplicationRevision>
+    <ApplicationRevision>2</ApplicationRevision>
     <ApplicationVersion>0.2.0.%2a</ApplicationVersion>
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>

--- a/libguinget/My Project/AssemblyInfo.vb
+++ b/libguinget/My Project/AssemblyInfo.vb
@@ -31,5 +31,5 @@ Imports System.Runtime.InteropServices
 ' by using the '*' as shown below:
 ' <Assembly: AssemblyVersion("1.0.*")> 
 
-<Assembly: AssemblyVersion("0.2.0.1")>
-<Assembly: AssemblyFileVersion("0.2.0.1")>
+<Assembly: AssemblyVersion("0.2.0.2")>
+<Assembly: AssemblyFileVersion("0.2.0.2")>

--- a/libguinget/PackageTools.vb
+++ b/libguinget/PackageTools.vb
@@ -157,6 +157,12 @@ Public Class PackageTools
     End Sub
 #End Region
 
+#Region "Get default locale file for multi-file manifest."
+    Public Shared Async Function GetDefaultLocaleFilePathForMultiFileManifest(ManifestPath As String) As Task(Of String)
+
+    End Function
+#End Region
+
 #Region "Get package details from YAML"
     Public Shared Async Function GetPackageInfoFromYamlAsync(ManifestPath As String, RequestedKey As String) As Task(Of String)
 

--- a/libguinget/PackageTools.vb
+++ b/libguinget/PackageTools.vb
@@ -159,7 +159,16 @@ Public Class PackageTools
 
 #Region "Get default locale file for multi-file manifest."
     Public Shared Async Function GetDefaultLocaleFilePathForMultiFileManifest(ManifestPath As String) As Task(Of String)
+        ' Define default locale file path string and remove
+        ' file extension from the original path.
+        Dim DefaultLocaleFilePath = ManifestPath.Remove(ManifestPath.Length - 5)
 
+        ' Add default locale and re-add file extension.
+        DefaultLocaleFilePath = DefaultLocaleFilePath & ".locale." &
+            Await GetPackageInfoFromYamlAsync(ManifestPath, "DefaultLocale") &
+            ".yaml"
+
+        Return DefaultLocaleFilePath
     End Function
 #End Region
 

--- a/libguinget/PackageTools.vb
+++ b/libguinget/PackageTools.vb
@@ -158,13 +158,13 @@ Public Class PackageTools
 #End Region
 
 #Region "Get default locale file for multi-file manifest."
-    Public Shared Async Function GetDefaultLocaleFilePathForMultiFileManifest(ManifestPath As String) As Task(Of String)
+    Public Shared Async Function GetMultiFileManifestPieceFilePath(ManifestPath As String, ManifestType As String, Optional DefaultLocale As String = Nothing) As Task(Of String)
         ' Define default locale file path string and remove
         ' file extension from the original path.
         Dim DefaultLocaleFilePath = ManifestPath.Remove(ManifestPath.Length - 5)
 
         ' Add default locale and re-add file extension.
-        DefaultLocaleFilePath = DefaultLocaleFilePath & ".locale." &
+        DefaultLocaleFilePath = DefaultLocaleFilePath & "." & ManifestType & "." &
             Await GetPackageInfoFromYamlAsync(ManifestPath, "DefaultLocale") &
             ".yaml"
 

--- a/libguinget/PackageTools.vb
+++ b/libguinget/PackageTools.vb
@@ -158,17 +158,28 @@ Public Class PackageTools
 #End Region
 
 #Region "Get default locale file for multi-file manifest."
-    Public Shared Async Function GetMultiFileManifestPieceFilePath(ManifestPath As String, ManifestType As String, Optional DefaultLocale As String = Nothing) As Task(Of String)
-        ' Define default locale file path string and remove
+    Public Shared Async Function GetMultiFileManifestPieceFilePath(ManifestPath As String, ManifestType As String) As Task(Of String)
+        ' Define piece file path string and remove
         ' file extension from the original path.
-        Dim DefaultLocaleFilePath = ManifestPath.Remove(ManifestPath.Length - 5)
+        Dim PieceFilePath = ManifestPath.Remove(ManifestPath.Length - 5)
 
-        ' Add default locale and re-add file extension.
-        DefaultLocaleFilePath = DefaultLocaleFilePath & "." & ManifestType & "." &
+        ' Check if we want the installer or default locale file.
+        If ManifestType = "defaultLocale" Then
+
+            ' Add default locale stuff and re-add file extension.
+            PieceFilePath = PieceFilePath & ".locale." &
             Await GetPackageInfoFromYamlAsync(ManifestPath, "DefaultLocale") &
             ".yaml"
 
-        Return DefaultLocaleFilePath
+        ElseIf ManifestType = "installer" Then
+
+            ' Add "installer" to the file path and re-add file extension.
+            PieceFilePath = PieceFilePath & ".installer.yaml"
+
+        End If
+
+        ' Now we're done and can return the path.
+        Return PieceFilePath
     End Function
 #End Region
 

--- a/libguinget/PackageTools.vb
+++ b/libguinget/PackageTools.vb
@@ -30,7 +30,7 @@ Imports YamlDotNet.RepresentationModel
 
 Public Class PackageTools
 
-#Region "Variables"
+#Region "Variables that act as settings."
     ' Specifying version numbers.
     Public Shared SpecifyVersionOnInstall As Boolean = True
     Public Shared SpecifyVersionOnUpgrade As Boolean = False

--- a/libguinget/libguinget.vbproj
+++ b/libguinget/libguinget.vbproj
@@ -89,8 +89,8 @@
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="System.Net.Http" />
-    <Reference Include="YamlDotNet, Version=10.0.0.0, Culture=neutral, PublicKeyToken=ec19458f3c15af5e, processorArchitecture=MSIL">
-      <HintPath>..\packages\YamlDotNet.10.0.0\lib\net45\YamlDotNet.dll</HintPath>
+    <Reference Include="YamlDotNet, Version=11.0.0.0, Culture=neutral, PublicKeyToken=ec19458f3c15af5e, processorArchitecture=MSIL">
+      <HintPath>..\packages\YamlDotNet.11.0.1\lib\net45\YamlDotNet.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/libguinget/packages.config
+++ b/libguinget/packages.config
@@ -10,5 +10,5 @@
   <package id="System.Memory" version="4.5.4" targetFramework="net48" />
   <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net48" />
   <package id="System.Runtime.CompilerServices.Unsafe" version="5.0.0" targetFramework="net48" />
-  <package id="YamlDotNet" version="10.0.0" targetFramework="net48" />
+  <package id="YamlDotNet" version="11.0.1" targetFramework="net48" />
 </packages>


### PR DESCRIPTION
This PR includes a few things:
- Initial support for multi-file manifests. A future version will probably improve how multi-file manifests are displayed to reduce duplicate information.
- YamlDotNet was updated to 11.0.1.
- A package's `ShortDescription` is now stored in a string so we don't have to load the manifest multiple times just to load the description when we're checking to see if it's the package ID.
- Single-file manifests now have a "Manifest" heading in the package details textbox for consistency with multi-file manifests.