### PR TITLE
Faster cache updates and package list loading.

### DIFF
--- a/guinget/MainWindow.vb
+++ b/guinget/MainWindow.vb
@@ -166,6 +166,9 @@ Public Class aaformMainWindow
         ' Update loading label.
         aaformMainWindow.toolstripstatuslabelLoadingPackageCount.Text = "Loading package details..."
 
+        ' Set the progress bar back to 0.
+        aaformMainWindow.toolstripprogressbarLoadingPackages.Value = 0
+
         ' Update the main window again after making the list visible and changing the loading label.
         aaformMainWindow.Update()
 

--- a/guinget/MainWindow.vb
+++ b/guinget/MainWindow.vb
@@ -95,6 +95,7 @@ Public Class aaformMainWindow
             Exit Function
         End If
 
+#Region "Deprecated manifest-only loading."
         ' Go through everything in the manifest paths array until it's out if
         ' we don't want to load from a database.
         If My.Settings.LoadFromSqliteDb = False Then
@@ -111,6 +112,7 @@ Public Class aaformMainWindow
                 ' Update the statusbar to show the current info.
                 aaformMainWindow.statusbarMainWindow.Update()
             Next
+#End Region
         Else
             ' We do want to load from the database, so do it.
 
@@ -121,6 +123,9 @@ Public Class aaformMainWindow
             ' This has to be done here or there will be a crash
             ' if we can't find all the manifests.
             aaformMainWindow.toolstripprogressbarLoadingPackages.Maximum = SqliteList.Rows.Count - 1
+
+            ' Update the statusbar before doing the progressbar.
+            aaformMainWindow.statusbarMainWindow.Update()
 
             'MessageBox.Show(SqliteList.Rows.Item(0).ToString)
             'aaformMainWindow.datagridviewPackageList.DataSource = SqliteList
@@ -145,7 +150,10 @@ Public Class aaformMainWindow
                 ' Make the progress bar progress.
                 aaformMainWindow.toolstripprogressbarLoadingPackages.PerformStep()
                 ' Update the statusbar to show the current info.
-                aaformMainWindow.statusbarMainWindow.Update()
+                ' Currently commented out because it's faster to not
+                ' update the statusbar every time, but to instead
+                ' rely on it just updating automatically.
+                'aaformMainWindow.statusbarMainWindow.Update()
             Next
         End If
 
@@ -199,6 +207,9 @@ Public Class aaformMainWindow
             ' will crash when the path doesn't exist.
             PackageListTools.FallbackPathList = PackageListTools.GetManifests
 
+            ' Update the statusbar before doing the progressbar.
+            aaformMainWindow.statusbarMainWindow.Update()
+
             ' Now we need to load the manifests and the descriptions.
             For Each PackageRow As DataGridViewRow In aaformMainWindow.datagridviewPackageList.Rows
                 ' Find the manifest and get its description.
@@ -250,7 +261,10 @@ Public Class aaformMainWindow
                 ' Make the progress bar progress.
                 aaformMainWindow.toolstripprogressbarLoadingPackages.Value = PackageRow.Index
                 ' Update the statusbar to show the current info.
-                aaformMainWindow.statusbarMainWindow.Update()
+                ' Currently commented out because it's faster to not
+                ' update the statusbar every time, but to instead
+                ' rely on it just updating automatically.
+                'aaformMainWindow.statusbarMainWindow.Update()
             Next
         End If
 

--- a/libguinget/PackageListTools.vb
+++ b/libguinget/PackageListTools.vb
@@ -306,7 +306,7 @@ Public Class PackageListTools
                     ' extracted.
                     ' Another test showed it takes about 2 minutes 12 seconds detached from
                     ' the debugger, then one a few minutes later took about 2 minutes 8 seconds.
-                    ' Another test with the current ectraction and copy code took about 3 minutes 2 seconds,
+                    ' Another test with the current extraction and copy code took about 3 minutes 2 seconds,
                     ' so it's still faster.
 
                     ' Check if the zip file exists before extracting it.

--- a/libguinget/PackageListTools.vb
+++ b/libguinget/PackageListTools.vb
@@ -318,7 +318,11 @@ Public Class PackageListTools
                                                            ' example had it so we're doing it here.
                                                            If DestinationPath.StartsWith(tempDir, StringComparison.OrdinalIgnoreCase) Then
                                                                ' Debugging to see where it gets stuck.
-                                                               Debug.WriteLine(DestinationPath)
+                                                               'Debug.WriteLine(DestinationPath)
+
+                                                               ' Make sure to create the directory for the manifest.
+                                                               IO.Directory.CreateDirectory(DestinationPath.Replace(ZipArchiveEntry.Name, String.Empty))
+
                                                                ' Now extract.
                                                                ZipArchiveEntry.ExtractToFile(DestinationPath)
                                                            End If
@@ -331,7 +335,7 @@ Public Class PackageListTools
                                            MessageBox.Show("Couldn't find " & tempDir & "\winget-pkgs-master.zip",
                                            "Extracting manifests")
                                        Catch ex As System.IO.DirectoryNotFoundException
-                                           MessageBox.Show("Couldn't find " & tempDir & "\winget-pkgs-master",
+                                           MessageBox.Show(ex.Message,
                                            "Extracting manifests")
                                        Catch ex As System.IO.InvalidDataException
                                            MessageBox.Show("We couldn't extract the manifest package. Please verify that the source URL is correct, and try again." & vbCrLf &

--- a/libguinget/PackageListTools.vb
+++ b/libguinget/PackageListTools.vb
@@ -286,8 +286,6 @@ Public Class PackageListTools
                 ' StackOverflow answer would work:
                 ' https://stackoverflow.com/a/39668142
 
-                ' Temporary, basic error handler in case we can't find
-                ' the zip file we want to extract.
                 If Use7zip = False Then
                     ' If the calling app doesn't want to use 7zip, use the built-in .Net extraction.
                     ' During testing on my laptop, using 7zip and robocopy reduced the cache updating time from
@@ -314,6 +312,8 @@ Public Class PackageListTools
                     ' This ZipArchiveEntry thing is based on MSDN code for extraction from here:
                     ' https://docs.microsoft.com/en-us/dotnet/api/system.io.compression.ziparchiveentry?view=netframework-4.8
 
+                    ' Temporary, basic error handler in case we can't find
+                    ' the zip file we want to extract.
                     Try
                         If System.IO.File.Exists(tempDir & "\winget-pkgs-master.zip") Then
 

--- a/libguinget/PackageListTools.vb
+++ b/libguinget/PackageListTools.vb
@@ -302,10 +302,12 @@ Public Class PackageListTools
                     ' with the debugger attached, or about 1 minute 35 seconds when detached.
                     ' That's still a 10-second improvement even when showing what file is being
                     ' extracted.
-                    ' Another test showed it takes about 2 minutes 12 seconds detached from
+                    ' Another test with the laptop unplugged showed it takes about 2 minutes 12 seconds detached from
                     ' the debugger, then one a few minutes later took about 2 minutes 8 seconds.
                     ' Another test with the current extraction and copy code took about 3 minutes 2 seconds,
                     ' so it's still faster.
+                    ' It appears that using "Better performance" makes the extraction go faster,
+                    ' which is to be expected.
 
                     ' Check if the zip file exists before extracting it.
 
@@ -355,6 +357,7 @@ Public Class PackageListTools
                                     End If
                                 Next
                             End Using
+                            ' Old extraction code.
                             'ZipFile.ExtractToDirectory(tempDir & "\winget-pkgs-master.zip", tempDir & "\winget-pkgs-master\")
                         End If
                     Catch ex As System.IO.FileNotFoundException
@@ -519,7 +522,7 @@ Public Class PackageListTools
                                 MessageBox.Show("Please close any Explorer windows that may be open in this directory, and try again." & vbCrLf &
                                                                vbCrLf &
                                                                "Details:" & vbCrLf &
-                                                               ex.Message, "Moving database")
+                                                               ex.Message, "Moving manifests")
                             End Try
                         End If
 

--- a/libguinget/PackageListTools.vb
+++ b/libguinget/PackageListTools.vb
@@ -318,7 +318,11 @@ Public Class PackageListTools
                                                            ' example had it so we're doing it here.
                                                            If DestinationPath.StartsWith(tempDir, StringComparison.OrdinalIgnoreCase) Then
                                                                ' Debugging to see where it gets stuck.
-                                                               'Debug.WriteLine(DestinationPath)
+                                                               Debug.WriteLine(DestinationPath)
+
+                                                               ' TODO: This doesn't go to the correct root folder, so it'll have to be added
+                                                               ' as a subdirectory when extracting. In this case,
+                                                               ' we need to create a second "winget-pkgs-master".
 
                                                                ' Make sure to create the directory for the manifest.
                                                                IO.Directory.CreateDirectory(DestinationPath.Replace(ZipArchiveEntry.Name, String.Empty))

--- a/libguinget/PackageListTools.vb
+++ b/libguinget/PackageListTools.vb
@@ -293,7 +293,7 @@ Public Class PackageListTools
                     ' During testing on my laptop, using 7zip and robocopy reduced the cache updating time from
                     ' 1 minute 40 seconds to about 1 minute 4 seconds.
                     ' New testing shows that the improved zip file extraction code
-                    ' now takes about 1 minute 35 seconds and the 7-zip and RoboCopy combination
+                    ' now takes about 1 minute 36 seconds and the 7-zip and RoboCopy combination
                     ' takes about 1 minute 11 seconds. This is also with the debugger attached and
                     ' Firefox open with a bunch of tabs.
 

--- a/libguinget/PackageListTools.vb
+++ b/libguinget/PackageListTools.vb
@@ -300,6 +300,10 @@ Public Class PackageListTools
                     ' still get about 1 minute 4 seconds.
                     ' Testing with v0.2.0.2 gets about 1 minute 45 seconds, so this is an improvement
                     ' of roughly 20 seconds.
+                    ' Showing the filename as we extract it makes it take about 1 minute 45 seconds
+                    ' with the debugger attached, or about 1 minute 35 seconds when detached.
+                    ' That's still a 10-second improvement even when showing what file is being
+                    ' extracted.
 
                     ' Check if the zip file exists before extracting it.
 
@@ -327,6 +331,13 @@ Public Class PackageListTools
                                         If DestinationPath.StartsWith(tempDir & "\winget-pkgs-master", StringComparison.OrdinalIgnoreCase) Then
                                             ' Debugging to see where it gets stuck.
                                             'Debug.WriteLine(DestinationPath)
+
+                                            ' Update the current filename.
+                                            ' Even with showing the current filename, it's
+                                            ' still faster than the old way of extracting
+                                            ' every file.
+                                            progressform.labelSourceName.Visible = True
+                                            progressform.labelSourceName.Text = "File: " & ZipArchiveEntry.Name.ToString
 
                                             ' Make sure to create the directory for the manifest.
                                             Await Task.Run(Sub()

--- a/libguinget/PackageListTools.vb
+++ b/libguinget/PackageListTools.vb
@@ -292,10 +292,11 @@ Public Class PackageListTools
                     ' If the calling app doesn't want to use 7zip, use the built-in .Net extraction.
                     ' During testing on my laptop, using 7zip and robocopy reduced the cache updating time from
                     ' 1 minute 40 seconds to about 1 minute 4 seconds.
-                    ' New testing shows that the improved zip file extraction code
+                    ' New testing as of 5/28/2021 shows that the improved zip file extraction code
                     ' now takes about 1 minute 36 seconds and the 7-zip and RoboCopy combination
                     ' takes about 1 minute 11 seconds. This is also with the debugger attached and
                     ' Firefox open with a bunch of tabs.
+                    ' Without the debugger attached, I got about 1 minute 25 seconds.
 
                     ' Check if the zip file exists before extracting it.
 

--- a/libguinget/PackageListTools.vb
+++ b/libguinget/PackageListTools.vb
@@ -345,10 +345,9 @@ Public Class PackageListTools
                                             progressform.labelSourceName.Visible = True
                                             progressform.labelSourceName.Text = "File: " & ZipArchiveEntry.Name.ToString
 
-                                            ' Make sure to create the directory for the manifest.
                                             Await Task.Run(Sub()
+                                                               ' Make sure to create the directory for the manifest.
                                                                IO.Directory.CreateDirectory(DestinationPath.Replace(ZipArchiveEntry.Name, String.Empty))
-
 
                                                                ' Now extract.
                                                                ZipArchiveEntry.ExtractToFile(DestinationPath)

--- a/libguinget/PackageListTools.vb
+++ b/libguinget/PackageListTools.vb
@@ -347,6 +347,8 @@ Public Class PackageListTools
 
                                             Await Task.Run(Sub()
                                                                ' Make sure to create the directory for the manifest.
+                                                               ' TODO: Make sure there's a "\" at the end of the path
+                                                               ' to prevent path traversal.
                                                                IO.Directory.CreateDirectory(DestinationPath.Replace(ZipArchiveEntry.Name, String.Empty))
 
                                                                ' Now extract.

--- a/libguinget/PackageListTools.vb
+++ b/libguinget/PackageListTools.vb
@@ -296,7 +296,8 @@ Public Class PackageListTools
                     ' now takes about 1 minute 36 seconds and the 7-zip and RoboCopy combination
                     ' takes about 1 minute 11 seconds. This is also with the debugger attached and
                     ' Firefox open with a bunch of tabs.
-                    ' Without the debugger attached, I got about 1 minute 25 seconds.
+                    ' Without the debugger attached, I got about 1 minute 25 seconds. Robocopy + 7-Zip
+                    ' still get about 1 minute 4 seconds.
 
                     ' Check if the zip file exists before extracting it.
 

--- a/libguinget/PackageListTools.vb
+++ b/libguinget/PackageListTools.vb
@@ -327,10 +327,11 @@ Public Class PackageListTools
                                             ' Make sure to create the directory for the manifest.
                                             Await Task.Run(Sub()
                                                                IO.Directory.CreateDirectory(DestinationPath.Replace(ZipArchiveEntry.Name, String.Empty))
-                                                           End Sub)
 
-                                            ' Now extract.
-                                            ZipArchiveEntry.ExtractToFile(DestinationPath)
+
+                                                               ' Now extract.
+                                                               ZipArchiveEntry.ExtractToFile(DestinationPath)
+                                                           End Sub)
                                         End If
                                     End If
                                 Next

--- a/libguinget/PackageListTools.vb
+++ b/libguinget/PackageListTools.vb
@@ -298,6 +298,8 @@ Public Class PackageListTools
                     ' Firefox open with a bunch of tabs.
                     ' Without the debugger attached, I got about 1 minute 25 seconds. Robocopy + 7-Zip
                     ' still get about 1 minute 4 seconds.
+                    ' Testing with v0.2.0.2 gets about 1 minute 45 seconds, so this is an improvement
+                    ' of roughly 20 seconds.
 
                     ' Check if the zip file exists before extracting it.
 

--- a/libguinget/PackageListTools.vb
+++ b/libguinget/PackageListTools.vb
@@ -301,6 +301,7 @@ Public Class PackageListTools
 
                                        Try
                                            If System.IO.File.Exists(tempDir & "\winget-pkgs-master.zip") Then
+
                                                ' Now extract.
                                                Using ManifestsZipFile As ZipArchive = ZipFile.OpenRead(tempDir & "\winget-pkgs-master.zip")
                                                    For Each ZipArchiveEntry In ManifestsZipFile.Entries
@@ -311,18 +312,14 @@ Public Class PackageListTools
                                                        If ZipArchiveEntry.FullName.EndsWith(".yaml", StringComparison.OrdinalIgnoreCase) Then
 
                                                            ' The final place where extracted files will be.
-                                                           Dim DestinationPath As String = Path.GetFullPath(Path.Combine(tempDir, ZipArchiveEntry.FullName))
+                                                           Dim DestinationPath As String = Path.GetFullPath(Path.Combine(tempDir & "\winget-pkgs-master", ZipArchiveEntry.FullName))
 
                                                            ' Not sure why we're checking if the destination path
                                                            ' starts with the extraction directory, but the
                                                            ' example had it so we're doing it here.
-                                                           If DestinationPath.StartsWith(tempDir, StringComparison.OrdinalIgnoreCase) Then
+                                                           If DestinationPath.StartsWith(tempDir & "\winget-pkgs-master", StringComparison.OrdinalIgnoreCase) Then
                                                                ' Debugging to see where it gets stuck.
-                                                               Debug.WriteLine(DestinationPath)
-
-                                                               ' TODO: This doesn't go to the correct root folder, so it'll have to be added
-                                                               ' as a subdirectory when extracting. In this case,
-                                                               ' we need to create a second "winget-pkgs-master".
+                                                               'Debug.WriteLine(DestinationPath)
 
                                                                ' Make sure to create the directory for the manifest.
                                                                IO.Directory.CreateDirectory(DestinationPath.Replace(ZipArchiveEntry.Name, String.Empty))

--- a/libguinget/PackageListTools.vb
+++ b/libguinget/PackageListTools.vb
@@ -292,6 +292,10 @@ Public Class PackageListTools
                     ' If the calling app doesn't want to use 7zip, use the built-in .Net extraction.
                     ' During testing on my laptop, using 7zip and robocopy reduced the cache updating time from
                     ' 1 minute 40 seconds to about 1 minute 4 seconds.
+                    ' New testing shows that the improved zip file extraction code
+                    ' now takes about 1 minute 35 seconds and the 7-zip and RoboCopy combination
+                    ' takes about 1 minute 11 seconds. This is also with the debugger attached and
+                    ' Firefox open with a bunch of tabs.
 
                     ' Check if the zip file exists before extracting it.
 
@@ -318,7 +322,7 @@ Public Class PackageListTools
                                         ' example had it so we're doing it here.
                                         If DestinationPath.StartsWith(tempDir & "\winget-pkgs-master", StringComparison.OrdinalIgnoreCase) Then
                                             ' Debugging to see where it gets stuck.
-                                            Debug.WriteLine(DestinationPath)
+                                            'Debug.WriteLine(DestinationPath)
 
                                             ' Make sure to create the directory for the manifest.
                                             Await Task.Run(Sub()

--- a/libguinget/libguinget.vbproj
+++ b/libguinget/libguinget.vbproj
@@ -72,6 +72,7 @@
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Data" />
     <Reference Include="System.Drawing" />
+    <Reference Include="System.IO.Compression" />
     <Reference Include="System.IO.Compression.FileSystem" />
     <Reference Include="System.Memory, Version=4.0.1.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Memory.4.5.4\lib\net461\System.Memory.dll</HintPath>


### PR DESCRIPTION
Now we only extract the manifests to save about 10 seconds when my laptop is on "Better performance" mode, or almost a minute when it's on "Better battery". As a result of the extra time budget, the current file that's being extracted is now shown in the "Extracting manifests" window. Moving the manifests instead of copying them further improves cache update times.

Additionally, the statusbar isn't updated every time a package is added to the package list, thus further potentially improving performance since it's not having to redraw itself constantly. That may not be that helpful as sometimes adding packages to the list is fast and sometimes it's slow, even when updating the statusbar constantly.