### PR TITLE
Allow using KDE-style fast resize so that resizing the window is smooth when there are a lot of items in the package list.

### DIFF
--- a/guinget/App.config
+++ b/guinget/App.config
@@ -86,6 +86,9 @@
       <setting name="SpecifyVersionOnUninstall" serializeAs="String">
         <value>False</value>
       </setting>
+      <setting name="UseKDEStyleFastResize" serializeAs="String">
+        <value>False</value>
+      </setting>
     </guinget.My.MySettings>
   </userSettings>
   <runtime>

--- a/guinget/App.config
+++ b/guinget/App.config
@@ -87,7 +87,7 @@
         <value>False</value>
       </setting>
       <setting name="UseKDEStyleFastResize" serializeAs="String">
-        <value>False</value>
+        <value>True</value>
       </setting>
     </guinget.My.MySettings>
   </userSettings>

--- a/guinget/MainWindow.Designer.vb
+++ b/guinget/MainWindow.Designer.vb
@@ -96,6 +96,7 @@ Partial Class aaformMainWindow
         Me.textboxPackageDetails = New System.Windows.Forms.RichTextBox()
         Me.contextmenuPackageDetailsTextbox = New System.Windows.Forms.ContextMenuStrip(Me.components)
         Me.CopyToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
+        Me.ToolStripSeparator2 = New System.Windows.Forms.ToolStripSeparator()
         Me.SelectAllToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
         Me.ToolStripSeparator1 = New System.Windows.Forms.ToolStripSeparator()
         Me.RightToLeftMenuItem = New System.Windows.Forms.ToolStripMenuItem()
@@ -144,7 +145,7 @@ Partial Class aaformMainWindow
         Me.TypeTimer = New System.Windows.Forms.Timer(Me.components)
         Me.SaveFileDialogExportPackages = New System.Windows.Forms.SaveFileDialog()
         Me.OpenFileDialogImportPackages = New System.Windows.Forms.OpenFileDialog()
-        Me.ToolStripSeparator2 = New System.Windows.Forms.ToolStripSeparator()
+        Me.pictureboxFastResizePackageList = New System.Windows.Forms.PictureBox()
         Me.menustripMainWindow.SuspendLayout()
         Me.contextmenustripPackageMenu.SuspendLayout()
         CType(Me.splitcontainerMainWindow, System.ComponentModel.ISupportInitialize).BeginInit()
@@ -172,6 +173,7 @@ Partial Class aaformMainWindow
         Me.tabpageArchitecture.SuspendLayout()
         Me.panelMainForm.SuspendLayout()
         Me.statusbarMainWindow.SuspendLayout()
+        CType(Me.pictureboxFastResizePackageList, System.ComponentModel.ISupportInitialize).BeginInit()
         Me.SuspendLayout()
         '
         'menustripMainWindow
@@ -180,7 +182,7 @@ Partial Class aaformMainWindow
         Me.menustripMainWindow.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.FileToolStripMenuItem, Me.ViewToolStripMenuItem, Me.PackageToolStripMenuItem, Me.SelectedPackagesToolStripMenuItem, Me.ToolsToolStripMenuItem, Me.HelpToolStripMenuItem})
         Me.menustripMainWindow.Location = New System.Drawing.Point(0, 0)
         Me.menustripMainWindow.Name = "menustripMainWindow"
-        Me.menustripMainWindow.Size = New System.Drawing.Size(1105, 30)
+        Me.menustripMainWindow.Size = New System.Drawing.Size(1105, 28)
         Me.menustripMainWindow.TabIndex = 0
         Me.menustripMainWindow.Text = "MenuStrip1"
         '
@@ -188,7 +190,7 @@ Partial Class aaformMainWindow
         '
         Me.FileToolStripMenuItem.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.ToolStripMenuItemImportPackages, Me.ToolStripMenuItemExportPackages, Me.zFileMenuSeparator2, Me.RunCMDToolStripMenuItem, Me.RunCMDElevatedToolStripMenuItem, Me.zFileMenuSeparator, Me.ExitToolStripMenuItem})
         Me.FileToolStripMenuItem.Name = "FileToolStripMenuItem"
-        Me.FileToolStripMenuItem.Size = New System.Drawing.Size(46, 26)
+        Me.FileToolStripMenuItem.Size = New System.Drawing.Size(46, 24)
         Me.FileToolStripMenuItem.Text = "&File"
         '
         'ToolStripMenuItemImportPackages
@@ -243,7 +245,7 @@ Partial Class aaformMainWindow
         '
         Me.ViewToolStripMenuItem.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.SidebarToolStripMenuItem, Me.zToolStripSeparatorViewMenu, Me.ListInstalledPackagesToolStripMenuItem, Me.ShowUpgradesToolStripMenuItem})
         Me.ViewToolStripMenuItem.Name = "ViewToolStripMenuItem"
-        Me.ViewToolStripMenuItem.Size = New System.Drawing.Size(55, 26)
+        Me.ViewToolStripMenuItem.Size = New System.Drawing.Size(55, 24)
         Me.ViewToolStripMenuItem.Text = "&View"
         '
         'SidebarToolStripMenuItem
@@ -274,7 +276,7 @@ Partial Class aaformMainWindow
         '
         Me.PackageToolStripMenuItem.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.RefreshCacheMenuButton, Me.UpdateWingetSourcesMenuButton, Me.zSeparatorAfterRefreshPart, Me.ApplyChangesMenuItem, Me.zSeparatorPackageListMenu, Me.SearchMenuItem, Me.AdvancedSearchMenuItem})
         Me.PackageToolStripMenuItem.Name = "PackageToolStripMenuItem"
-        Me.PackageToolStripMenuItem.Size = New System.Drawing.Size(100, 26)
+        Me.PackageToolStripMenuItem.Size = New System.Drawing.Size(100, 24)
         Me.PackageToolStripMenuItem.Text = "&Package list"
         '
         'RefreshCacheMenuButton
@@ -326,7 +328,7 @@ Partial Class aaformMainWindow
         '
         Me.SelectedPackagesToolStripMenuItem.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.SelectedPackagesActionDoNothingMenuItem, Me.SelectedPackagesActionInstallMenuItem, Me.SelectedPackagesActionUninstallMenuItem, Me.SelectedPackagesActionUpgradeMenuItem, Me.zSeparatorAfterActionsInSelectedPackagesMenu, Me.SelectedPackagesSearchForLastSelectedID, Me.zSeparatorSelectedPackagesMenu, Me.ShowInWingetToolStripMenuItem, Me.SelectedPackagesProperties})
         Me.SelectedPackagesToolStripMenuItem.Name = "SelectedPackagesToolStripMenuItem"
-        Me.SelectedPackagesToolStripMenuItem.Size = New System.Drawing.Size(146, 26)
+        Me.SelectedPackagesToolStripMenuItem.Size = New System.Drawing.Size(146, 24)
         Me.SelectedPackagesToolStripMenuItem.Text = "&Selected packages"
         '
         'SelectedPackagesActionDoNothingMenuItem
@@ -390,7 +392,7 @@ Partial Class aaformMainWindow
         '
         Me.ToolsToolStripMenuItem.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.VerifyManifestToolStripMenuItem, Me.FindManifestToolStripMenuItem, Me.zSeparatorAboveEditWingetSettings, Me.EditWingetSettingsToolStripMenuItem, Me.EditWingetSettingsAsAdminToolStripMenuItem, Me.OptionsToolStripMenuItem})
         Me.ToolsToolStripMenuItem.Name = "ToolsToolStripMenuItem"
-        Me.ToolsToolStripMenuItem.Size = New System.Drawing.Size(58, 26)
+        Me.ToolsToolStripMenuItem.Size = New System.Drawing.Size(58, 24)
         Me.ToolsToolStripMenuItem.Text = "&Tools"
         '
         'VerifyManifestToolStripMenuItem
@@ -432,7 +434,7 @@ Partial Class aaformMainWindow
         '
         Me.HelpToolStripMenuItem.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.HowToUseGuingetToolStripMenuItem, Me.HelpMenuToolStripSeparator, Me.AboutToolStripMenuItem})
         Me.HelpToolStripMenuItem.Name = "HelpToolStripMenuItem"
-        Me.HelpToolStripMenuItem.Size = New System.Drawing.Size(55, 26)
+        Me.HelpToolStripMenuItem.Size = New System.Drawing.Size(55, 24)
         Me.HelpToolStripMenuItem.Text = "&Help"
         '
         'HowToUseGuingetToolStripMenuItem
@@ -529,19 +531,20 @@ Partial Class aaformMainWindow
         'splitcontainerMainWindow.Panel2
         '
         Me.splitcontainerMainWindow.Panel2.Controls.Add(Me.textboxPackageDetails)
-        Me.splitcontainerMainWindow.Size = New System.Drawing.Size(830, 635)
-        Me.splitcontainerMainWindow.SplitterDistance = 422
+        Me.splitcontainerMainWindow.Size = New System.Drawing.Size(830, 641)
+        Me.splitcontainerMainWindow.SplitterDistance = 425
         Me.splitcontainerMainWindow.TabIndex = 4
         '
         'panelPackageListHolder
         '
         Me.panelPackageListHolder.Controls.Add(Me.datagridviewPackageList)
+        Me.panelPackageListHolder.Controls.Add(Me.pictureboxFastResizePackageList)
         Me.panelPackageListHolder.Controls.Add(Me.labelUpdatingPackageList)
         Me.panelPackageListHolder.Dock = System.Windows.Forms.DockStyle.Fill
         Me.panelPackageListHolder.Location = New System.Drawing.Point(0, 0)
         Me.panelPackageListHolder.Margin = New System.Windows.Forms.Padding(2)
         Me.panelPackageListHolder.Name = "panelPackageListHolder"
-        Me.panelPackageListHolder.Size = New System.Drawing.Size(830, 422)
+        Me.panelPackageListHolder.Size = New System.Drawing.Size(830, 425)
         Me.panelPackageListHolder.TabIndex = 2
         '
         'datagridviewPackageList
@@ -589,7 +592,7 @@ Partial Class aaformMainWindow
         Me.datagridviewPackageList.RowTemplate.Height = 24
         Me.datagridviewPackageList.SelectionMode = System.Windows.Forms.DataGridViewSelectionMode.FullRowSelect
         Me.datagridviewPackageList.ShowEditingIcon = False
-        Me.datagridviewPackageList.Size = New System.Drawing.Size(830, 422)
+        Me.datagridviewPackageList.Size = New System.Drawing.Size(830, 425)
         Me.datagridviewPackageList.StandardTab = True
         Me.datagridviewPackageList.TabIndex = 0
         '
@@ -688,7 +691,7 @@ Partial Class aaformMainWindow
         Me.textboxPackageDetails.Name = "textboxPackageDetails"
         Me.textboxPackageDetails.ReadOnly = True
         Me.textboxPackageDetails.ScrollBars = System.Windows.Forms.RichTextBoxScrollBars.Vertical
-        Me.textboxPackageDetails.Size = New System.Drawing.Size(830, 209)
+        Me.textboxPackageDetails.Size = New System.Drawing.Size(830, 212)
         Me.textboxPackageDetails.TabIndex = 0
         Me.textboxPackageDetails.Text = resources.GetString("textboxPackageDetails.Text")
         '
@@ -697,13 +700,18 @@ Partial Class aaformMainWindow
         Me.contextmenuPackageDetailsTextbox.ImageScalingSize = New System.Drawing.Size(20, 20)
         Me.contextmenuPackageDetailsTextbox.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.CopyToolStripMenuItem, Me.ToolStripSeparator2, Me.SelectAllToolStripMenuItem, Me.ToolStripSeparator1, Me.RightToLeftMenuItem})
         Me.contextmenuPackageDetailsTextbox.Name = "contextmenuPackageDetailsTextbox"
-        Me.contextmenuPackageDetailsTextbox.Size = New System.Drawing.Size(257, 116)
+        Me.contextmenuPackageDetailsTextbox.Size = New System.Drawing.Size(257, 88)
         '
         'CopyToolStripMenuItem
         '
         Me.CopyToolStripMenuItem.Name = "CopyToolStripMenuItem"
         Me.CopyToolStripMenuItem.Size = New System.Drawing.Size(256, 24)
         Me.CopyToolStripMenuItem.Text = "Copy"
+        '
+        'ToolStripSeparator2
+        '
+        Me.ToolStripSeparator2.Name = "ToolStripSeparator2"
+        Me.ToolStripSeparator2.Size = New System.Drawing.Size(253, 6)
         '
         'SelectAllToolStripMenuItem
         '
@@ -729,16 +737,16 @@ Partial Class aaformMainWindow
         Me.panelMainPkgArea.Location = New System.Drawing.Point(0, 0)
         Me.panelMainPkgArea.Margin = New System.Windows.Forms.Padding(2)
         Me.panelMainPkgArea.Name = "panelMainPkgArea"
-        Me.panelMainPkgArea.Size = New System.Drawing.Size(830, 635)
+        Me.panelMainPkgArea.Size = New System.Drawing.Size(830, 641)
         Me.panelMainPkgArea.TabIndex = 2
         '
         'toolstripMainWindow
         '
         Me.toolstripMainWindow.ImageScalingSize = New System.Drawing.Size(20, 20)
         Me.toolstripMainWindow.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.toolstripbuttonRefreshCache, Me.toolstripbuttonApplyChanges, Me.zSeparatorApplyChangesAndProperties, Me.toolstripbuttonProperties, Me.zSeparatorPropertiesAndSearchBox, Me.toolstriptextboxSearch, Me.toolstripsplitbuttonSearch})
-        Me.toolstripMainWindow.Location = New System.Drawing.Point(0, 30)
+        Me.toolstripMainWindow.Location = New System.Drawing.Point(0, 28)
         Me.toolstripMainWindow.Name = "toolstripMainWindow"
-        Me.toolstripMainWindow.Size = New System.Drawing.Size(1105, 31)
+        Me.toolstripMainWindow.Size = New System.Drawing.Size(1105, 27)
         Me.toolstripMainWindow.TabIndex = 6
         Me.toolstripMainWindow.TabStop = True
         Me.toolstripMainWindow.Text = "ToolStrip1"
@@ -749,7 +757,7 @@ Partial Class aaformMainWindow
         Me.toolstripbuttonRefreshCache.Image = CType(resources.GetObject("toolstripbuttonRefreshCache.Image"), System.Drawing.Image)
         Me.toolstripbuttonRefreshCache.ImageTransparentColor = System.Drawing.Color.Magenta
         Me.toolstripbuttonRefreshCache.Name = "toolstripbuttonRefreshCache"
-        Me.toolstripbuttonRefreshCache.Size = New System.Drawing.Size(104, 28)
+        Me.toolstripbuttonRefreshCache.Size = New System.Drawing.Size(104, 24)
         Me.toolstripbuttonRefreshCache.Text = "Refresh cache"
         Me.toolstripbuttonRefreshCache.TextImageRelation = System.Windows.Forms.TextImageRelation.ImageAboveText
         '
@@ -759,14 +767,14 @@ Partial Class aaformMainWindow
         Me.toolstripbuttonApplyChanges.Image = CType(resources.GetObject("toolstripbuttonApplyChanges.Image"), System.Drawing.Image)
         Me.toolstripbuttonApplyChanges.ImageTransparentColor = System.Drawing.Color.Magenta
         Me.toolstripbuttonApplyChanges.Name = "toolstripbuttonApplyChanges"
-        Me.toolstripbuttonApplyChanges.Size = New System.Drawing.Size(119, 28)
+        Me.toolstripbuttonApplyChanges.Size = New System.Drawing.Size(119, 24)
         Me.toolstripbuttonApplyChanges.Text = "Apply changes..."
         Me.toolstripbuttonApplyChanges.TextImageRelation = System.Windows.Forms.TextImageRelation.ImageAboveText
         '
         'zSeparatorApplyChangesAndProperties
         '
         Me.zSeparatorApplyChangesAndProperties.Name = "zSeparatorApplyChangesAndProperties"
-        Me.zSeparatorApplyChangesAndProperties.Size = New System.Drawing.Size(6, 31)
+        Me.zSeparatorApplyChangesAndProperties.Size = New System.Drawing.Size(6, 27)
         '
         'toolstripbuttonProperties
         '
@@ -774,21 +782,21 @@ Partial Class aaformMainWindow
         Me.toolstripbuttonProperties.Image = CType(resources.GetObject("toolstripbuttonProperties.Image"), System.Drawing.Image)
         Me.toolstripbuttonProperties.ImageTransparentColor = System.Drawing.Color.Magenta
         Me.toolstripbuttonProperties.Name = "toolstripbuttonProperties"
-        Me.toolstripbuttonProperties.Size = New System.Drawing.Size(89, 28)
+        Me.toolstripbuttonProperties.Size = New System.Drawing.Size(89, 24)
         Me.toolstripbuttonProperties.Text = "Properties..."
         Me.toolstripbuttonProperties.TextImageRelation = System.Windows.Forms.TextImageRelation.ImageAboveText
         '
         'zSeparatorPropertiesAndSearchBox
         '
         Me.zSeparatorPropertiesAndSearchBox.Name = "zSeparatorPropertiesAndSearchBox"
-        Me.zSeparatorPropertiesAndSearchBox.Size = New System.Drawing.Size(6, 31)
+        Me.zSeparatorPropertiesAndSearchBox.Size = New System.Drawing.Size(6, 27)
         '
         'toolstriptextboxSearch
         '
         Me.toolstriptextboxSearch.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle
         Me.toolstriptextboxSearch.Font = New System.Drawing.Font("Segoe UI", 9.0!)
         Me.toolstriptextboxSearch.Name = "toolstriptextboxSearch"
-        Me.toolstriptextboxSearch.Size = New System.Drawing.Size(250, 31)
+        Me.toolstriptextboxSearch.Size = New System.Drawing.Size(250, 27)
         '
         'toolstripsplitbuttonSearch
         '
@@ -797,7 +805,7 @@ Partial Class aaformMainWindow
         Me.toolstripsplitbuttonSearch.Image = CType(resources.GetObject("toolstripsplitbuttonSearch.Image"), System.Drawing.Image)
         Me.toolstripsplitbuttonSearch.ImageTransparentColor = System.Drawing.Color.Magenta
         Me.toolstripsplitbuttonSearch.Name = "toolstripsplitbuttonSearch"
-        Me.toolstripsplitbuttonSearch.Size = New System.Drawing.Size(72, 28)
+        Me.toolstripsplitbuttonSearch.Size = New System.Drawing.Size(72, 24)
         Me.toolstripsplitbuttonSearch.Text = "Search"
         '
         'toolstripmenuitemAdvancedSearch
@@ -820,7 +828,7 @@ Partial Class aaformMainWindow
         'splitcontainerSidebarAndPkgList.Panel2
         '
         Me.splitcontainerSidebarAndPkgList.Panel2.Controls.Add(Me.panelMainPkgArea)
-        Me.splitcontainerSidebarAndPkgList.Size = New System.Drawing.Size(1105, 635)
+        Me.splitcontainerSidebarAndPkgList.Size = New System.Drawing.Size(1105, 641)
         Me.splitcontainerSidebarAndPkgList.SplitterDistance = 271
         Me.splitcontainerSidebarAndPkgList.TabIndex = 5
         '
@@ -833,7 +841,7 @@ Partial Class aaformMainWindow
         Me.panelSidebarHolder.Location = New System.Drawing.Point(0, 0)
         Me.panelSidebarHolder.Margin = New System.Windows.Forms.Padding(2)
         Me.panelSidebarHolder.Name = "panelSidebarHolder"
-        Me.panelSidebarHolder.Size = New System.Drawing.Size(271, 635)
+        Me.panelSidebarHolder.Size = New System.Drawing.Size(271, 641)
         Me.panelSidebarHolder.TabIndex = 0
         '
         'buttonCloseSidebar
@@ -880,7 +888,7 @@ Partial Class aaformMainWindow
         Me.tabcontrolSidebar.Margin = New System.Windows.Forms.Padding(2)
         Me.tabcontrolSidebar.Name = "tabcontrolSidebar"
         Me.tabcontrolSidebar.SelectedIndex = 0
-        Me.tabcontrolSidebar.Size = New System.Drawing.Size(262, 600)
+        Me.tabcontrolSidebar.Size = New System.Drawing.Size(262, 606)
         Me.tabcontrolSidebar.SizeMode = System.Windows.Forms.TabSizeMode.Fixed
         Me.tabcontrolSidebar.TabIndex = 2
         '
@@ -890,7 +898,7 @@ Partial Class aaformMainWindow
         Me.tabpageSearchTerms.Location = New System.Drawing.Point(4, 5)
         Me.tabpageSearchTerms.Margin = New System.Windows.Forms.Padding(2)
         Me.tabpageSearchTerms.Name = "tabpageSearchTerms"
-        Me.tabpageSearchTerms.Size = New System.Drawing.Size(254, 591)
+        Me.tabpageSearchTerms.Size = New System.Drawing.Size(254, 597)
         Me.tabpageSearchTerms.TabIndex = 4
         Me.tabpageSearchTerms.Text = "Search terms"
         Me.tabpageSearchTerms.UseVisualStyleBackColor = True
@@ -906,7 +914,7 @@ Partial Class aaformMainWindow
         Me.listboxSearchTerms.Location = New System.Drawing.Point(0, 0)
         Me.listboxSearchTerms.Margin = New System.Windows.Forms.Padding(2)
         Me.listboxSearchTerms.Name = "listboxSearchTerms"
-        Me.listboxSearchTerms.Size = New System.Drawing.Size(254, 591)
+        Me.listboxSearchTerms.Size = New System.Drawing.Size(254, 597)
         Me.listboxSearchTerms.TabIndex = 2
         '
         'contextmenuSearchTerm
@@ -939,7 +947,7 @@ Partial Class aaformMainWindow
         Me.tabpageAction.Location = New System.Drawing.Point(4, 5)
         Me.tabpageAction.Margin = New System.Windows.Forms.Padding(2)
         Me.tabpageAction.Name = "tabpageAction"
-        Me.tabpageAction.Size = New System.Drawing.Size(254, 597)
+        Me.tabpageAction.Size = New System.Drawing.Size(254, 591)
         Me.tabpageAction.TabIndex = 6
         Me.tabpageAction.Text = "Action"
         Me.tabpageAction.UseVisualStyleBackColor = True
@@ -954,7 +962,7 @@ Partial Class aaformMainWindow
         Me.listboxActions.Location = New System.Drawing.Point(0, 0)
         Me.listboxActions.Margin = New System.Windows.Forms.Padding(2)
         Me.listboxActions.Name = "listboxActions"
-        Me.listboxActions.Size = New System.Drawing.Size(254, 597)
+        Me.listboxActions.Size = New System.Drawing.Size(254, 591)
         Me.listboxActions.TabIndex = 2
         '
         'tabpageStatus
@@ -963,7 +971,7 @@ Partial Class aaformMainWindow
         Me.tabpageStatus.Location = New System.Drawing.Point(4, 5)
         Me.tabpageStatus.Margin = New System.Windows.Forms.Padding(2)
         Me.tabpageStatus.Name = "tabpageStatus"
-        Me.tabpageStatus.Size = New System.Drawing.Size(254, 597)
+        Me.tabpageStatus.Size = New System.Drawing.Size(254, 591)
         Me.tabpageStatus.TabIndex = 1
         Me.tabpageStatus.Text = "Status"
         Me.tabpageStatus.UseVisualStyleBackColor = True
@@ -978,7 +986,7 @@ Partial Class aaformMainWindow
         Me.listboxStatusTab.Location = New System.Drawing.Point(0, 0)
         Me.listboxStatusTab.Margin = New System.Windows.Forms.Padding(2)
         Me.listboxStatusTab.Name = "listboxStatusTab"
-        Me.listboxStatusTab.Size = New System.Drawing.Size(254, 597)
+        Me.listboxStatusTab.Size = New System.Drawing.Size(254, 591)
         Me.listboxStatusTab.TabIndex = 0
         '
         'tabpageCustomFilters
@@ -987,7 +995,7 @@ Partial Class aaformMainWindow
         Me.tabpageCustomFilters.Location = New System.Drawing.Point(4, 5)
         Me.tabpageCustomFilters.Margin = New System.Windows.Forms.Padding(2)
         Me.tabpageCustomFilters.Name = "tabpageCustomFilters"
-        Me.tabpageCustomFilters.Size = New System.Drawing.Size(254, 597)
+        Me.tabpageCustomFilters.Size = New System.Drawing.Size(254, 591)
         Me.tabpageCustomFilters.TabIndex = 3
         Me.tabpageCustomFilters.Text = "Custom filters"
         Me.tabpageCustomFilters.UseVisualStyleBackColor = True
@@ -1002,7 +1010,7 @@ Partial Class aaformMainWindow
         Me.listboxCustomFilters.Location = New System.Drawing.Point(0, 0)
         Me.listboxCustomFilters.Margin = New System.Windows.Forms.Padding(2)
         Me.listboxCustomFilters.Name = "listboxCustomFilters"
-        Me.listboxCustomFilters.Size = New System.Drawing.Size(254, 597)
+        Me.listboxCustomFilters.Size = New System.Drawing.Size(254, 591)
         Me.listboxCustomFilters.TabIndex = 1
         '
         'tabpageSections
@@ -1011,7 +1019,7 @@ Partial Class aaformMainWindow
         Me.tabpageSections.Location = New System.Drawing.Point(4, 5)
         Me.tabpageSections.Margin = New System.Windows.Forms.Padding(2)
         Me.tabpageSections.Name = "tabpageSections"
-        Me.tabpageSections.Size = New System.Drawing.Size(254, 597)
+        Me.tabpageSections.Size = New System.Drawing.Size(254, 591)
         Me.tabpageSections.TabIndex = 0
         Me.tabpageSections.Text = "Categories"
         Me.tabpageSections.UseVisualStyleBackColor = True
@@ -1026,7 +1034,7 @@ Partial Class aaformMainWindow
         Me.listboxSections.Location = New System.Drawing.Point(0, 0)
         Me.listboxSections.Margin = New System.Windows.Forms.Padding(2)
         Me.listboxSections.Name = "listboxSections"
-        Me.listboxSections.Size = New System.Drawing.Size(254, 597)
+        Me.listboxSections.Size = New System.Drawing.Size(254, 591)
         Me.listboxSections.TabIndex = 1
         '
         'tabpageSource
@@ -1035,7 +1043,7 @@ Partial Class aaformMainWindow
         Me.tabpageSource.Location = New System.Drawing.Point(4, 5)
         Me.tabpageSource.Margin = New System.Windows.Forms.Padding(2)
         Me.tabpageSource.Name = "tabpageSource"
-        Me.tabpageSource.Size = New System.Drawing.Size(254, 597)
+        Me.tabpageSource.Size = New System.Drawing.Size(254, 591)
         Me.tabpageSource.TabIndex = 2
         Me.tabpageSource.Text = "Source"
         Me.tabpageSource.UseVisualStyleBackColor = True
@@ -1050,7 +1058,7 @@ Partial Class aaformMainWindow
         Me.listboxSourceTab.Location = New System.Drawing.Point(0, 0)
         Me.listboxSourceTab.Margin = New System.Windows.Forms.Padding(2)
         Me.listboxSourceTab.Name = "listboxSourceTab"
-        Me.listboxSourceTab.Size = New System.Drawing.Size(254, 597)
+        Me.listboxSourceTab.Size = New System.Drawing.Size(254, 591)
         Me.listboxSourceTab.TabIndex = 1
         '
         'tabpageArchitecture
@@ -1059,7 +1067,7 @@ Partial Class aaformMainWindow
         Me.tabpageArchitecture.Location = New System.Drawing.Point(4, 5)
         Me.tabpageArchitecture.Margin = New System.Windows.Forms.Padding(2)
         Me.tabpageArchitecture.Name = "tabpageArchitecture"
-        Me.tabpageArchitecture.Size = New System.Drawing.Size(254, 597)
+        Me.tabpageArchitecture.Size = New System.Drawing.Size(254, 591)
         Me.tabpageArchitecture.TabIndex = 5
         Me.tabpageArchitecture.Text = "Architecture"
         Me.tabpageArchitecture.UseVisualStyleBackColor = True
@@ -1074,17 +1082,17 @@ Partial Class aaformMainWindow
         Me.listboxArchitecture.Location = New System.Drawing.Point(0, 0)
         Me.listboxArchitecture.Margin = New System.Windows.Forms.Padding(2)
         Me.listboxArchitecture.Name = "listboxArchitecture"
-        Me.listboxArchitecture.Size = New System.Drawing.Size(254, 597)
+        Me.listboxArchitecture.Size = New System.Drawing.Size(254, 591)
         Me.listboxArchitecture.TabIndex = 1
         '
         'panelMainForm
         '
         Me.panelMainForm.Controls.Add(Me.splitcontainerSidebarAndPkgList)
         Me.panelMainForm.Dock = System.Windows.Forms.DockStyle.Fill
-        Me.panelMainForm.Location = New System.Drawing.Point(0, 61)
+        Me.panelMainForm.Location = New System.Drawing.Point(0, 55)
         Me.panelMainForm.Margin = New System.Windows.Forms.Padding(2)
         Me.panelMainForm.Name = "panelMainForm"
-        Me.panelMainForm.Size = New System.Drawing.Size(1105, 635)
+        Me.panelMainForm.Size = New System.Drawing.Size(1105, 641)
         Me.panelMainForm.TabIndex = 4
         '
         'statusbarMainWindow
@@ -1157,10 +1165,15 @@ Partial Class aaformMainWindow
         Me.OpenFileDialogImportPackages.RestoreDirectory = True
         Me.OpenFileDialogImportPackages.Title = "Import Packages"
         '
-        'ToolStripSeparator2
+        'pictureboxFastResizePackageList
         '
-        Me.ToolStripSeparator2.Name = "ToolStripSeparator2"
-        Me.ToolStripSeparator2.Size = New System.Drawing.Size(253, 6)
+        Me.pictureboxFastResizePackageList.Dock = System.Windows.Forms.DockStyle.Fill
+        Me.pictureboxFastResizePackageList.Location = New System.Drawing.Point(0, 0)
+        Me.pictureboxFastResizePackageList.Name = "pictureboxFastResizePackageList"
+        Me.pictureboxFastResizePackageList.Size = New System.Drawing.Size(830, 425)
+        Me.pictureboxFastResizePackageList.TabIndex = 2
+        Me.pictureboxFastResizePackageList.TabStop = False
+        Me.pictureboxFastResizePackageList.Visible = False
         '
         'aaformMainWindow
         '
@@ -1207,6 +1220,7 @@ Partial Class aaformMainWindow
         Me.panelMainForm.ResumeLayout(False)
         Me.statusbarMainWindow.ResumeLayout(False)
         Me.statusbarMainWindow.PerformLayout()
+        CType(Me.pictureboxFastResizePackageList, System.ComponentModel.ISupportInitialize).EndInit()
         Me.ResumeLayout(False)
         Me.PerformLayout()
 
@@ -1330,4 +1344,5 @@ Partial Class aaformMainWindow
     Friend WithEvents ToolStripSeparator1 As ToolStripSeparator
     Friend WithEvents RightToLeftMenuItem As ToolStripMenuItem
     Friend WithEvents ToolStripSeparator2 As ToolStripSeparator
+    Friend WithEvents pictureboxFastResizePackageList As PictureBox
 End Class

--- a/guinget/MainWindow.Designer.vb
+++ b/guinget/MainWindow.Designer.vb
@@ -92,6 +92,7 @@ Partial Class aaformMainWindow
         Me.PkgDescription = New System.Windows.Forms.DataGridViewTextBoxColumn()
         Me.Manifest = New System.Windows.Forms.DataGridViewTextBoxColumn()
         Me.ManifestType = New System.Windows.Forms.DataGridViewTextBoxColumn()
+        Me.pictureboxFastResizePackageList = New System.Windows.Forms.PictureBox()
         Me.labelUpdatingPackageList = New System.Windows.Forms.Label()
         Me.textboxPackageDetails = New System.Windows.Forms.RichTextBox()
         Me.contextmenuPackageDetailsTextbox = New System.Windows.Forms.ContextMenuStrip(Me.components)
@@ -145,7 +146,6 @@ Partial Class aaformMainWindow
         Me.TypeTimer = New System.Windows.Forms.Timer(Me.components)
         Me.SaveFileDialogExportPackages = New System.Windows.Forms.SaveFileDialog()
         Me.OpenFileDialogImportPackages = New System.Windows.Forms.OpenFileDialog()
-        Me.pictureboxFastResizePackageList = New System.Windows.Forms.PictureBox()
         Me.menustripMainWindow.SuspendLayout()
         Me.contextmenustripPackageMenu.SuspendLayout()
         CType(Me.splitcontainerMainWindow, System.ComponentModel.ISupportInitialize).BeginInit()
@@ -154,6 +154,7 @@ Partial Class aaformMainWindow
         Me.splitcontainerMainWindow.SuspendLayout()
         Me.panelPackageListHolder.SuspendLayout()
         CType(Me.datagridviewPackageList, System.ComponentModel.ISupportInitialize).BeginInit()
+        CType(Me.pictureboxFastResizePackageList, System.ComponentModel.ISupportInitialize).BeginInit()
         Me.contextmenuPackageDetailsTextbox.SuspendLayout()
         Me.panelMainPkgArea.SuspendLayout()
         Me.toolstripMainWindow.SuspendLayout()
@@ -173,7 +174,6 @@ Partial Class aaformMainWindow
         Me.tabpageArchitecture.SuspendLayout()
         Me.panelMainForm.SuspendLayout()
         Me.statusbarMainWindow.SuspendLayout()
-        CType(Me.pictureboxFastResizePackageList, System.ComponentModel.ISupportInitialize).BeginInit()
         Me.SuspendLayout()
         '
         'menustripMainWindow
@@ -669,6 +669,17 @@ Partial Class aaformMainWindow
         Me.ManifestType.ReadOnly = True
         Me.ManifestType.Visible = False
         '
+        'pictureboxFastResizePackageList
+        '
+        Me.pictureboxFastResizePackageList.Dock = System.Windows.Forms.DockStyle.Fill
+        Me.pictureboxFastResizePackageList.Location = New System.Drawing.Point(0, 0)
+        Me.pictureboxFastResizePackageList.Name = "pictureboxFastResizePackageList"
+        Me.pictureboxFastResizePackageList.Size = New System.Drawing.Size(830, 425)
+        Me.pictureboxFastResizePackageList.SizeMode = System.Windows.Forms.PictureBoxSizeMode.StretchImage
+        Me.pictureboxFastResizePackageList.TabIndex = 2
+        Me.pictureboxFastResizePackageList.TabStop = False
+        Me.pictureboxFastResizePackageList.Visible = False
+        '
         'labelUpdatingPackageList
         '
         Me.labelUpdatingPackageList.Anchor = CType((((System.Windows.Forms.AnchorStyles.Top Or System.Windows.Forms.AnchorStyles.Bottom) _
@@ -947,7 +958,7 @@ Partial Class aaformMainWindow
         Me.tabpageAction.Location = New System.Drawing.Point(4, 5)
         Me.tabpageAction.Margin = New System.Windows.Forms.Padding(2)
         Me.tabpageAction.Name = "tabpageAction"
-        Me.tabpageAction.Size = New System.Drawing.Size(254, 591)
+        Me.tabpageAction.Size = New System.Drawing.Size(254, 597)
         Me.tabpageAction.TabIndex = 6
         Me.tabpageAction.Text = "Action"
         Me.tabpageAction.UseVisualStyleBackColor = True
@@ -962,7 +973,7 @@ Partial Class aaformMainWindow
         Me.listboxActions.Location = New System.Drawing.Point(0, 0)
         Me.listboxActions.Margin = New System.Windows.Forms.Padding(2)
         Me.listboxActions.Name = "listboxActions"
-        Me.listboxActions.Size = New System.Drawing.Size(254, 591)
+        Me.listboxActions.Size = New System.Drawing.Size(254, 597)
         Me.listboxActions.TabIndex = 2
         '
         'tabpageStatus
@@ -971,7 +982,7 @@ Partial Class aaformMainWindow
         Me.tabpageStatus.Location = New System.Drawing.Point(4, 5)
         Me.tabpageStatus.Margin = New System.Windows.Forms.Padding(2)
         Me.tabpageStatus.Name = "tabpageStatus"
-        Me.tabpageStatus.Size = New System.Drawing.Size(254, 591)
+        Me.tabpageStatus.Size = New System.Drawing.Size(254, 597)
         Me.tabpageStatus.TabIndex = 1
         Me.tabpageStatus.Text = "Status"
         Me.tabpageStatus.UseVisualStyleBackColor = True
@@ -986,7 +997,7 @@ Partial Class aaformMainWindow
         Me.listboxStatusTab.Location = New System.Drawing.Point(0, 0)
         Me.listboxStatusTab.Margin = New System.Windows.Forms.Padding(2)
         Me.listboxStatusTab.Name = "listboxStatusTab"
-        Me.listboxStatusTab.Size = New System.Drawing.Size(254, 591)
+        Me.listboxStatusTab.Size = New System.Drawing.Size(254, 597)
         Me.listboxStatusTab.TabIndex = 0
         '
         'tabpageCustomFilters
@@ -995,7 +1006,7 @@ Partial Class aaformMainWindow
         Me.tabpageCustomFilters.Location = New System.Drawing.Point(4, 5)
         Me.tabpageCustomFilters.Margin = New System.Windows.Forms.Padding(2)
         Me.tabpageCustomFilters.Name = "tabpageCustomFilters"
-        Me.tabpageCustomFilters.Size = New System.Drawing.Size(254, 591)
+        Me.tabpageCustomFilters.Size = New System.Drawing.Size(254, 597)
         Me.tabpageCustomFilters.TabIndex = 3
         Me.tabpageCustomFilters.Text = "Custom filters"
         Me.tabpageCustomFilters.UseVisualStyleBackColor = True
@@ -1010,7 +1021,7 @@ Partial Class aaformMainWindow
         Me.listboxCustomFilters.Location = New System.Drawing.Point(0, 0)
         Me.listboxCustomFilters.Margin = New System.Windows.Forms.Padding(2)
         Me.listboxCustomFilters.Name = "listboxCustomFilters"
-        Me.listboxCustomFilters.Size = New System.Drawing.Size(254, 591)
+        Me.listboxCustomFilters.Size = New System.Drawing.Size(254, 597)
         Me.listboxCustomFilters.TabIndex = 1
         '
         'tabpageSections
@@ -1019,7 +1030,7 @@ Partial Class aaformMainWindow
         Me.tabpageSections.Location = New System.Drawing.Point(4, 5)
         Me.tabpageSections.Margin = New System.Windows.Forms.Padding(2)
         Me.tabpageSections.Name = "tabpageSections"
-        Me.tabpageSections.Size = New System.Drawing.Size(254, 591)
+        Me.tabpageSections.Size = New System.Drawing.Size(254, 597)
         Me.tabpageSections.TabIndex = 0
         Me.tabpageSections.Text = "Categories"
         Me.tabpageSections.UseVisualStyleBackColor = True
@@ -1034,7 +1045,7 @@ Partial Class aaformMainWindow
         Me.listboxSections.Location = New System.Drawing.Point(0, 0)
         Me.listboxSections.Margin = New System.Windows.Forms.Padding(2)
         Me.listboxSections.Name = "listboxSections"
-        Me.listboxSections.Size = New System.Drawing.Size(254, 591)
+        Me.listboxSections.Size = New System.Drawing.Size(254, 597)
         Me.listboxSections.TabIndex = 1
         '
         'tabpageSource
@@ -1043,7 +1054,7 @@ Partial Class aaformMainWindow
         Me.tabpageSource.Location = New System.Drawing.Point(4, 5)
         Me.tabpageSource.Margin = New System.Windows.Forms.Padding(2)
         Me.tabpageSource.Name = "tabpageSource"
-        Me.tabpageSource.Size = New System.Drawing.Size(254, 591)
+        Me.tabpageSource.Size = New System.Drawing.Size(254, 597)
         Me.tabpageSource.TabIndex = 2
         Me.tabpageSource.Text = "Source"
         Me.tabpageSource.UseVisualStyleBackColor = True
@@ -1058,7 +1069,7 @@ Partial Class aaformMainWindow
         Me.listboxSourceTab.Location = New System.Drawing.Point(0, 0)
         Me.listboxSourceTab.Margin = New System.Windows.Forms.Padding(2)
         Me.listboxSourceTab.Name = "listboxSourceTab"
-        Me.listboxSourceTab.Size = New System.Drawing.Size(254, 591)
+        Me.listboxSourceTab.Size = New System.Drawing.Size(254, 597)
         Me.listboxSourceTab.TabIndex = 1
         '
         'tabpageArchitecture
@@ -1067,7 +1078,7 @@ Partial Class aaformMainWindow
         Me.tabpageArchitecture.Location = New System.Drawing.Point(4, 5)
         Me.tabpageArchitecture.Margin = New System.Windows.Forms.Padding(2)
         Me.tabpageArchitecture.Name = "tabpageArchitecture"
-        Me.tabpageArchitecture.Size = New System.Drawing.Size(254, 591)
+        Me.tabpageArchitecture.Size = New System.Drawing.Size(254, 597)
         Me.tabpageArchitecture.TabIndex = 5
         Me.tabpageArchitecture.Text = "Architecture"
         Me.tabpageArchitecture.UseVisualStyleBackColor = True
@@ -1082,7 +1093,7 @@ Partial Class aaformMainWindow
         Me.listboxArchitecture.Location = New System.Drawing.Point(0, 0)
         Me.listboxArchitecture.Margin = New System.Windows.Forms.Padding(2)
         Me.listboxArchitecture.Name = "listboxArchitecture"
-        Me.listboxArchitecture.Size = New System.Drawing.Size(254, 591)
+        Me.listboxArchitecture.Size = New System.Drawing.Size(254, 597)
         Me.listboxArchitecture.TabIndex = 1
         '
         'panelMainForm
@@ -1165,16 +1176,6 @@ Partial Class aaformMainWindow
         Me.OpenFileDialogImportPackages.RestoreDirectory = True
         Me.OpenFileDialogImportPackages.Title = "Import Packages"
         '
-        'pictureboxFastResizePackageList
-        '
-        Me.pictureboxFastResizePackageList.Dock = System.Windows.Forms.DockStyle.Fill
-        Me.pictureboxFastResizePackageList.Location = New System.Drawing.Point(0, 0)
-        Me.pictureboxFastResizePackageList.Name = "pictureboxFastResizePackageList"
-        Me.pictureboxFastResizePackageList.Size = New System.Drawing.Size(830, 425)
-        Me.pictureboxFastResizePackageList.TabIndex = 2
-        Me.pictureboxFastResizePackageList.TabStop = False
-        Me.pictureboxFastResizePackageList.Visible = False
-        '
         'aaformMainWindow
         '
         Me.AutoScaleDimensions = New System.Drawing.SizeF(120.0!, 120.0!)
@@ -1198,6 +1199,7 @@ Partial Class aaformMainWindow
         Me.panelPackageListHolder.ResumeLayout(False)
         Me.panelPackageListHolder.PerformLayout()
         CType(Me.datagridviewPackageList, System.ComponentModel.ISupportInitialize).EndInit()
+        CType(Me.pictureboxFastResizePackageList, System.ComponentModel.ISupportInitialize).EndInit()
         Me.contextmenuPackageDetailsTextbox.ResumeLayout(False)
         Me.panelMainPkgArea.ResumeLayout(False)
         Me.toolstripMainWindow.ResumeLayout(False)
@@ -1220,7 +1222,6 @@ Partial Class aaformMainWindow
         Me.panelMainForm.ResumeLayout(False)
         Me.statusbarMainWindow.ResumeLayout(False)
         Me.statusbarMainWindow.PerformLayout()
-        CType(Me.pictureboxFastResizePackageList, System.ComponentModel.ISupportInitialize).EndInit()
         Me.ResumeLayout(False)
         Me.PerformLayout()
 

--- a/guinget/MainWindow.vb
+++ b/guinget/MainWindow.vb
@@ -1431,7 +1431,9 @@ Public Class aaformMainWindow
             RightToLeftMenuItem.Checked = False
         End If
     End Sub
+#End Region
 
+#Region "KDE-style fast resize."
     Private Sub aaformMainWindow_ResizeBegin(sender As Object, e As EventArgs) Handles Me.ResizeBegin
         ' The window started to resize, so we need to
         ' take a screenshot of the package list

--- a/guinget/MainWindow.vb
+++ b/guinget/MainWindow.vb
@@ -1431,6 +1431,44 @@ Public Class aaformMainWindow
             RightToLeftMenuItem.Checked = False
         End If
     End Sub
+
+    Private Sub aaformMainWindow_ResizeBegin(sender As Object, e As EventArgs) Handles Me.ResizeBegin
+        ' Create an image that we'll copy into.
+        ' Code based on these SO answers:
+        ' https://stackoverflow.com/a/33454625
+        ' https://stackoverflow.com/a/23805004
+        ' At first the code was mainly from the
+        ' second one, but it ended up mainly being
+        ' from the second one mostly I think.
+        Dim packagelistScreenshot As New Bitmap(datagridviewPackageList.Width, datagridviewPackageList.Height)
+
+        ' This thing copies the screenshot of the package list
+        ' into the screenshot we'll show later.
+        Using graphicsCopier As Graphics = Graphics.FromImage(packagelistScreenshot)
+            graphicsCopier.CopyFromScreen(datagridviewPackageList.PointToScreen(New Point(0, 0)), New Point(0, 0), New Drawing.Size(datagridviewPackageList.Width, datagridviewPackageList.Height))
+        End Using
+
+        ' Assign the screenshot to the imagebox.
+        pictureboxFastResizePackageList.Image = packagelistScreenshot
+
+        ' Change visibility for the package list and
+        ' the screenshot picturebox.
+        pictureboxFastResizePackageList.Visible = True
+        datagridviewPackageList.Visible = False
+
+        ' Bring the picturebox to the front.
+        pictureboxFastResizePackageList.BringToFront()
+    End Sub
+
+    Private Sub aaformMainWindow_ResizeEnd(sender As Object, e As EventArgs) Handles Me.ResizeEnd
+        ' Change visibility so the package list is
+        ' again visible and the picturebox isn't.
+        pictureboxFastResizePackageList.Visible = False
+        datagridviewPackageList.Visible = True
+
+        ' Bring the package list to the front.
+        datagridviewPackageList.BringToFront()
+    End Sub
 #End Region
 
 

--- a/guinget/MainWindow.vb
+++ b/guinget/MainWindow.vb
@@ -1433,41 +1433,52 @@ Public Class aaformMainWindow
     End Sub
 
     Private Sub aaformMainWindow_ResizeBegin(sender As Object, e As EventArgs) Handles Me.ResizeBegin
-        ' Create an image that we'll copy into.
-        ' Code based on these SO answers:
-        ' https://stackoverflow.com/a/33454625
-        ' https://stackoverflow.com/a/23805004
-        ' At first the code was mainly from the
-        ' second one, but it ended up mainly being
-        ' from the second one mostly I think.
-        Dim packagelistScreenshot As New Bitmap(datagridviewPackageList.Width, datagridviewPackageList.Height)
+        ' The window started to resize, so we need to
+        ' take a screenshot of the package list
+        ' and show it so resizing is fast.
+        ' Only do this if UseKDEStyleFastResize is on.
+        If My.Settings.UseKDEStyleFastResize = True Then
+            ' Create an image that we'll copy into.
+            ' Code based on these SO answers:
+            ' https://stackoverflow.com/a/33454625
+            ' https://stackoverflow.com/a/23805004
+            ' At first the code was mainly from the
+            ' second one, but it ended up mainly being
+            ' from the second one mostly I think.
+            Dim packagelistScreenshot As New Bitmap(datagridviewPackageList.Width, datagridviewPackageList.Height)
 
-        ' This thing copies the screenshot of the package list
-        ' into the screenshot we'll show later.
-        Using graphicsCopier As Graphics = Graphics.FromImage(packagelistScreenshot)
-            graphicsCopier.CopyFromScreen(datagridviewPackageList.PointToScreen(New Point(0, 0)), New Point(0, 0), New Drawing.Size(datagridviewPackageList.Width, datagridviewPackageList.Height))
-        End Using
+            ' This thing copies the screenshot of the package list
+            ' into the screenshot we'll show later.
+            Using graphicsCopier As Graphics = Graphics.FromImage(packagelistScreenshot)
+                graphicsCopier.CopyFromScreen(datagridviewPackageList.PointToScreen(New Point(0, 0)), New Point(0, 0), New Drawing.Size(datagridviewPackageList.Width, datagridviewPackageList.Height))
+            End Using
 
-        ' Assign the screenshot to the imagebox.
-        pictureboxFastResizePackageList.Image = packagelistScreenshot
+            ' Assign the screenshot to the imagebox.
+            pictureboxFastResizePackageList.Image = packagelistScreenshot
 
-        ' Change visibility for the package list and
-        ' the screenshot picturebox.
-        pictureboxFastResizePackageList.Visible = True
-        datagridviewPackageList.Visible = False
+            ' Change visibility for the package list and
+            ' the screenshot picturebox.
+            pictureboxFastResizePackageList.Visible = True
+            datagridviewPackageList.Visible = False
 
-        ' Bring the picturebox to the front.
-        pictureboxFastResizePackageList.BringToFront()
+            ' Bring the picturebox to the front.
+            pictureboxFastResizePackageList.BringToFront()
+        End If
     End Sub
 
     Private Sub aaformMainWindow_ResizeEnd(sender As Object, e As EventArgs) Handles Me.ResizeEnd
-        ' Change visibility so the package list is
-        ' again visible and the picturebox isn't.
-        pictureboxFastResizePackageList.Visible = False
-        datagridviewPackageList.Visible = True
+        ' We're done resizing, so set things back to
+        ' how they should be.
+        ' Only do this if UseKDEStyleFastResize is on.
+        If My.Settings.UseKDEStyleFastResize = True Then
+            ' Change visibility so the package list is
+            ' again visible and the picturebox isn't.
+            pictureboxFastResizePackageList.Visible = False
+            datagridviewPackageList.Visible = True
 
-        ' Bring the package list to the front.
-        datagridviewPackageList.BringToFront()
+            ' Bring the package list to the front.
+            datagridviewPackageList.BringToFront()
+        End If
     End Sub
 #End Region
 

--- a/guinget/My Project/Settings.Designer.vb
+++ b/guinget/My Project/Settings.Designer.vb
@@ -332,7 +332,7 @@ Namespace My
         
         <Global.System.Configuration.UserScopedSettingAttribute(),  _
          Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
-         Global.System.Configuration.DefaultSettingValueAttribute("False")>  _
+         Global.System.Configuration.DefaultSettingValueAttribute("True")>  _
         Public Property UseKDEStyleFastResize() As Boolean
             Get
                 Return CType(Me("UseKDEStyleFastResize"),Boolean)

--- a/guinget/My Project/Settings.Designer.vb
+++ b/guinget/My Project/Settings.Designer.vb
@@ -329,6 +329,18 @@ Namespace My
                 Me("SpecifyVersionOnUninstall") = value
             End Set
         End Property
+        
+        <Global.System.Configuration.UserScopedSettingAttribute(),  _
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
+         Global.System.Configuration.DefaultSettingValueAttribute("False")>  _
+        Public Property UseKDEStyleFastResize() As Boolean
+            Get
+                Return CType(Me("UseKDEStyleFastResize"),Boolean)
+            End Get
+            Set
+                Me("UseKDEStyleFastResize") = value
+            End Set
+        End Property
     End Class
 End Namespace
 

--- a/guinget/My Project/Settings.settings
+++ b/guinget/My Project/Settings.settings
@@ -72,7 +72,7 @@
       <Value Profile="(Default)">False</Value>
     </Setting>
     <Setting Name="UseKDEStyleFastResize" Type="System.Boolean" Scope="User">
-      <Value Profile="(Default)">False</Value>
+      <Value Profile="(Default)">True</Value>
     </Setting>
   </Settings>
 </SettingsFile>

--- a/guinget/My Project/Settings.settings
+++ b/guinget/My Project/Settings.settings
@@ -71,5 +71,8 @@
     <Setting Name="SpecifyVersionOnUninstall" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
+    <Setting Name="UseKDEStyleFastResize" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/guinget/OptionsWindow.Designer.vb
+++ b/guinget/OptionsWindow.Designer.vb
@@ -81,6 +81,9 @@ Partial Class OptionsWindow
         Me.buttonCancel = New System.Windows.Forms.Button()
         Me.buttonOk = New System.Windows.Forms.Button()
         Me.SevenZExeOpenFileDialog = New System.Windows.Forms.OpenFileDialog()
+        Me.checkboxUseKDEStyleFastResize = New System.Windows.Forms.CheckBox()
+        Me.groupboxPackageList = New System.Windows.Forms.GroupBox()
+        Me.groupboxPackageDetails = New System.Windows.Forms.GroupBox()
         Me.tablelayoutpanelOptions.SuspendLayout()
         Me.tabcontrolOptions.SuspendLayout()
         Me.tabpageRefreshCache.SuspendLayout()
@@ -93,6 +96,8 @@ Partial Class OptionsWindow
         Me.tabpageMaintenance.SuspendLayout()
         Me.tabpageExperimental.SuspendLayout()
         Me.panelExperimentalSettings.SuspendLayout()
+        Me.groupboxPackageList.SuspendLayout()
+        Me.groupboxPackageDetails.SuspendLayout()
         Me.SuspendLayout()
         '
         'tablelayoutpanelOptions
@@ -213,11 +218,11 @@ Partial Class OptionsWindow
         Me.tabpageSearch.Controls.Add(Me.checkboxSearchWhenTyping)
         Me.tabpageSearch.Controls.Add(Me.checkboxUseExactMatchForLastSelectedPackageIDSearch)
         Me.tabpageSearch.Controls.Add(Me.checkboxRerunSearch)
-        Me.tabpageSearch.Location = New System.Drawing.Point(4, 46)
+        Me.tabpageSearch.Location = New System.Drawing.Point(4, 25)
         Me.tabpageSearch.Margin = New System.Windows.Forms.Padding(2)
         Me.tabpageSearch.Name = "tabpageSearch"
         Me.tabpageSearch.Padding = New System.Windows.Forms.Padding(2)
-        Me.tabpageSearch.Size = New System.Drawing.Size(453, 446)
+        Me.tabpageSearch.Size = New System.Drawing.Size(453, 467)
         Me.tabpageSearch.TabIndex = 0
         Me.tabpageSearch.Text = "Search"
         Me.tabpageSearch.UseVisualStyleBackColor = True
@@ -281,11 +286,11 @@ Partial Class OptionsWindow
         Me.tabpageAppsUIs.Controls.Add(Me.labelAutomaticControlPanelFallback)
         Me.tabpageAppsUIs.Controls.Add(Me.comboboxAppsListUI)
         Me.tabpageAppsUIs.Controls.Add(Me.labelAppsListUI)
-        Me.tabpageAppsUIs.Location = New System.Drawing.Point(4, 46)
+        Me.tabpageAppsUIs.Location = New System.Drawing.Point(4, 25)
         Me.tabpageAppsUIs.Margin = New System.Windows.Forms.Padding(4)
         Me.tabpageAppsUIs.Name = "tabpageAppsUIs"
         Me.tabpageAppsUIs.Padding = New System.Windows.Forms.Padding(4)
-        Me.tabpageAppsUIs.Size = New System.Drawing.Size(453, 446)
+        Me.tabpageAppsUIs.Size = New System.Drawing.Size(453, 467)
         Me.tabpageAppsUIs.TabIndex = 6
         Me.tabpageAppsUIs.Text = "Apps and UIs"
         Me.tabpageAppsUIs.UseVisualStyleBackColor = True
@@ -324,21 +329,22 @@ Partial Class OptionsWindow
         '
         'tabpagePackageDetails
         '
-        Me.tabpagePackageDetails.Controls.Add(Me.checkboxLastSelectedPackageDetails)
+        Me.tabpagePackageDetails.Controls.Add(Me.groupboxPackageDetails)
+        Me.tabpagePackageDetails.Controls.Add(Me.groupboxPackageList)
         Me.tabpagePackageDetails.Location = New System.Drawing.Point(4, 46)
         Me.tabpagePackageDetails.Margin = New System.Windows.Forms.Padding(4)
         Me.tabpagePackageDetails.Name = "tabpagePackageDetails"
         Me.tabpagePackageDetails.Padding = New System.Windows.Forms.Padding(4)
         Me.tabpagePackageDetails.Size = New System.Drawing.Size(453, 446)
         Me.tabpagePackageDetails.TabIndex = 2
-        Me.tabpagePackageDetails.Text = "Package Details"
+        Me.tabpagePackageDetails.Text = "Package List + Details"
         Me.tabpagePackageDetails.UseVisualStyleBackColor = True
         '
         'checkboxLastSelectedPackageDetails
         '
         Me.checkboxLastSelectedPackageDetails.AutoSize = True
         Me.checkboxLastSelectedPackageDetails.CheckAlign = System.Drawing.ContentAlignment.TopLeft
-        Me.checkboxLastSelectedPackageDetails.Location = New System.Drawing.Point(8, 8)
+        Me.checkboxLastSelectedPackageDetails.Location = New System.Drawing.Point(7, 22)
         Me.checkboxLastSelectedPackageDetails.Margin = New System.Windows.Forms.Padding(4)
         Me.checkboxLastSelectedPackageDetails.Name = "checkboxLastSelectedPackageDetails"
         Me.checkboxLastSelectedPackageDetails.Size = New System.Drawing.Size(348, 38)
@@ -780,6 +786,38 @@ Partial Class OptionsWindow
         Me.SevenZExeOpenFileDialog.Filter = "EXE files|*.exe|All files|*.*"
         Me.SevenZExeOpenFileDialog.Title = "Browse for 7z.exe"
         '
+        'checkboxUseKDEStyleFastResize
+        '
+        Me.checkboxUseKDEStyleFastResize.AutoSize = True
+        Me.checkboxUseKDEStyleFastResize.CheckAlign = System.Drawing.ContentAlignment.TopLeft
+        Me.checkboxUseKDEStyleFastResize.Location = New System.Drawing.Point(6, 21)
+        Me.checkboxUseKDEStyleFastResize.Name = "checkboxUseKDEStyleFastResize"
+        Me.checkboxUseKDEStyleFastResize.Size = New System.Drawing.Size(361, 55)
+        Me.checkboxUseKDEStyleFastResize.TabIndex = 1
+        Me.checkboxUseKDEStyleFastResize.Text = "Use KDE-style fast resize for the package list so that" & Global.Microsoft.VisualBasic.ChrW(13) & Global.Microsoft.VisualBasic.ChrW(10) & "resizing the window is sm" &
+    "ooth when there are a lot" & Global.Microsoft.VisualBasic.ChrW(13) & Global.Microsoft.VisualBasic.ChrW(10) & "of packages listed"
+        Me.checkboxUseKDEStyleFastResize.UseVisualStyleBackColor = True
+        '
+        'groupboxPackageList
+        '
+        Me.groupboxPackageList.Controls.Add(Me.checkboxUseKDEStyleFastResize)
+        Me.groupboxPackageList.Location = New System.Drawing.Point(7, 103)
+        Me.groupboxPackageList.Name = "groupboxPackageList"
+        Me.groupboxPackageList.Size = New System.Drawing.Size(439, 90)
+        Me.groupboxPackageList.TabIndex = 2
+        Me.groupboxPackageList.TabStop = False
+        Me.groupboxPackageList.Text = "Package list"
+        '
+        'groupboxPackageDetails
+        '
+        Me.groupboxPackageDetails.Controls.Add(Me.checkboxLastSelectedPackageDetails)
+        Me.groupboxPackageDetails.Location = New System.Drawing.Point(7, 7)
+        Me.groupboxPackageDetails.Name = "groupboxPackageDetails"
+        Me.groupboxPackageDetails.Size = New System.Drawing.Size(439, 90)
+        Me.groupboxPackageDetails.TabIndex = 3
+        Me.groupboxPackageDetails.TabStop = False
+        Me.groupboxPackageDetails.Text = "Package details"
+        '
         'OptionsWindow
         '
         Me.AutoScaleDimensions = New System.Drawing.SizeF(120.0!, 120.0!)
@@ -806,7 +844,6 @@ Partial Class OptionsWindow
         Me.tabpageAppsUIs.ResumeLayout(False)
         Me.tabpageAppsUIs.PerformLayout()
         Me.tabpagePackageDetails.ResumeLayout(False)
-        Me.tabpagePackageDetails.PerformLayout()
         Me.tabpageApplyChanges.ResumeLayout(False)
         Me.tabpageApplyChanges.PerformLayout()
         Me.tabpageLayout.ResumeLayout(False)
@@ -817,6 +854,10 @@ Partial Class OptionsWindow
         Me.tabpageExperimental.PerformLayout()
         Me.panelExperimentalSettings.ResumeLayout(False)
         Me.panelExperimentalSettings.PerformLayout()
+        Me.groupboxPackageList.ResumeLayout(False)
+        Me.groupboxPackageList.PerformLayout()
+        Me.groupboxPackageDetails.ResumeLayout(False)
+        Me.groupboxPackageDetails.PerformLayout()
         Me.ResumeLayout(False)
 
     End Sub
@@ -879,4 +920,7 @@ Partial Class OptionsWindow
     Friend WithEvents checkboxWhenUninstalling As CheckBox
     Friend WithEvents labelLoadLatestVersion As Label
     Friend WithEvents checkboxShowOnlyLatestVersions As CheckBox
+    Friend WithEvents checkboxUseKDEStyleFastResize As CheckBox
+    Friend WithEvents groupboxPackageDetails As GroupBox
+    Friend WithEvents groupboxPackageList As GroupBox
 End Class

--- a/guinget/OptionsWindow.vb
+++ b/guinget/OptionsWindow.vb
@@ -73,6 +73,8 @@ Public Class OptionsWindow
 
         ' Show last-selected package details.
         checkboxLastSelectedPackageDetails.Checked = My.Settings.ShowLastSelectedPackageDetails
+        ' Use KDE-style fast resize.
+        checkboxUseKDEStyleFastResize.Checked = My.Settings.UseKDEStyleFastResize
 
         ' Use 7-Zip.
         checkboxUse7zip.Checked = My.Settings.Use7zipForExtraction
@@ -162,7 +164,8 @@ Public Class OptionsWindow
 
         ' Show last-selected package details.
         My.Settings.ShowLastSelectedPackageDetails = checkboxLastSelectedPackageDetails.Checked
-
+        ' Use KDE-style fast resize.
+        My.Settings.UseKDEStyleFastResize = checkboxUseKDEStyleFastResize.Checked
 
         ' Use 7-Zip.
         My.Settings.Use7zipForExtraction = checkboxUse7zip.Checked

--- a/guinget/OptionsWindow.vb
+++ b/guinget/OptionsWindow.vb
@@ -248,6 +248,8 @@ Public Class OptionsWindow
 
         ' Show last-selected package details.
         checkboxLastSelectedPackageDetails.Checked = True
+        ' Use KDE-style fast resize.
+        checkboxUseKDEStyleFastResize.Checked = True
 
         ' Use 7-Zip.
         checkboxUse7zip.Checked = False


### PR DESCRIPTION
KDE-style fast resize takes a screenshot of the window you're resizing and stretches it to cover the whole window until "yer dun" (sorry, I had to) resizing it, at which point it shows the real window again. In this case, we take a screenshot of the package list area, hide the package list, and show the screenshot in a picturebox. This picturebox shows windows on top of it such as the cache update progress dialog, but I think it's good enough and I don't want to overcomplicate things. This fast resize feature is on by default (since it makes things so much more responsive), but it can be turned off by unchecking the `Use KDE-style fast resize for the package list so that resizing the window is smooth when there are a lot of packages listed` checkbox under `Tools>Options...>Package List + Details`.

One side effect of fast resizing is that moving the window will cause the package list to redraw itself. Not sure how to stop it from doing that and only make it redraw on resize, maximize, or restore.

Something else that's different now is that the `Package Details` tab in the `Options` window is now `Package List + Details` to accommodate the fast resizing feature's checkbox without having to add more tabs that would be redundant. Additionally, the checkboxes on that tab have their own groupboxes to keep them visually separate.

Fixes #71.